### PR TITLE
changes heal pool work

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/HealPoolListner.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/HealPoolListner.java
@@ -13,7 +13,7 @@ import org.bukkit.event.Listener;
 public class HealPoolListner implements Listener {
     @EventHandler
     public void onTeamUpgrade(UpgradeBuyEvent e){
-        if (e.getTeamUpgrade().getName().equalsIgnoreCase("upgrade-heal-pool")){
+        if (e.getTeamUpgrade().getName().contains("heal-pool")){
             IArena a = e.getArena();
             if (a == null) return;
             ITeam bwt = a.getTeam(e.getPlayer());


### PR DESCRIPTION
Since the upgrade price is likely to be different for each arena group, if the upgrade has a heal-pool in the name, it is changed to work