### PR TITLE
Check if arena is running before disabling 

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/DisableArena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/DisableArena.java
@@ -68,7 +68,7 @@ public class DisableArena extends SubCommand {
             return true;
         }
         if (a.getStatus() == GameState.playing) {
-            p.sendMessage("§6 ▪ §7This arena can't be disabled during this game!");
+            p.sendMessage("§6 ▪ §7There is a game running on this Arena, please disable after the game!");
             return true;
         }
         p.sendMessage("§6 ▪ §7Disabling arena...");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/DisableArena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/DisableArena.java
@@ -21,6 +21,7 @@
 package com.andrei1058.bedwars.commands.bedwars.subcmds.sensitive;
 
 import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.arena.GameState;
 import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.command.ParentCommand;
 import com.andrei1058.bedwars.api.command.SubCommand;
@@ -64,6 +65,10 @@ public class DisableArena extends SubCommand {
         IArena a = Arena.getArenaByName(args[0]);
         if (a == null) {
             p.sendMessage("§c▪ §7This arena is disabled yet!");
+            return true;
+        }
+        if (a.getStatus() == GameState.playing) {
+            p.sendMessage("§6 ▪ §7This arena can't be disabled during this game!");
             return true;
         }
         p.sendMessage("§6 ▪ §7Disabling arena...");


### PR DESCRIPTION
Changed this arena to not be disabled if a game is in progress 

The reason for the change is that many errors occur when disableArena and enableArena. I will upload the file

[bedwars1058 bugs.txt](https://github.com/tomkeuper/BedWars1058/files/11343302/bedwars1058.bugs.txt)
