### PR TITLE
Added fix to prevent ConcurrentModificationException

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/addon/AddonManager.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/addon/AddonManager.java
@@ -62,6 +62,7 @@ public class AddonManager implements IAddonManager {
     @Override
     public void unloadAddons() {
         if (loadedAddons.isEmpty()) return;
+        List<Addon> loadedAddonsToRemove = new ArrayList<>();
         log("Unloading addons...");
         for (Addon addon : loadedAddons) {
             if (unloadedAddons.contains(addon)) continue;
@@ -79,10 +80,14 @@ public class AddonManager implements IAddonManager {
 
             log("Unloading " + name + " by " + author);
             unloadedAddons.add(addon);
-            loadedAddons.remove(addon);
+            loadedAddonsToRemove.add(addon);
             addon.unload();
             Bukkit.getPluginManager().disablePlugin(addon.getPlugin());
             log("Addon unloaded successfully!");
+        }
+
+        for (Addon addon : loadedAddonsToRemove) {
+            loadedAddons.remove(addon);
         }
     }
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/addon/AddonManager.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/addon/AddonManager.java
@@ -82,7 +82,9 @@ public class AddonManager implements IAddonManager {
             unloadedAddons.add(addon);
             loadedAddonsToRemove.add(addon);
             addon.unload();
-            Bukkit.getPluginManager().disablePlugin(addon.getPlugin());
+            if (Bukkit.getPluginManager().isPluginEnabled(addon.getPlugin())) {
+                Bukkit.getPluginManager().disablePlugin(addon.getPlugin());
+            }
             log("Addon unloaded successfully!");
         }
 


### PR DESCRIPTION
This prevents an error when trying to unload every single addon

The way we were using before was modifying the list when iterating through that list so that caused an error 