### PR TITLE
Improved generator item pick up to prevent lag

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/events/player/PlayerGeneratorCollectEvent.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/events/player/PlayerGeneratorCollectEvent.java
@@ -34,16 +34,18 @@ public class PlayerGeneratorCollectEvent extends Event {
     private final Player player;
     private final Item item;
     private final IArena arena;
+    private final int amount;
     private boolean cancelled = false;
 
     /**
      * Triggered when players collect from generators.
      * This is not hired when player will receive items in inv from gen-split feature. This feature can be disabled in bw config.
      */
-    public PlayerGeneratorCollectEvent(Player player, Item item, IArena arena) {
+    public PlayerGeneratorCollectEvent(Player player, Item item, IArena arena, int amount) {
         this.player = player;
         this.item = item;
         this.arena = arena;
+        this.amount = amount;
     }
 
     public IArena getArena() {
@@ -69,6 +71,13 @@ public class PlayerGeneratorCollectEvent extends Event {
      */
     public ItemStack getItemStack() {
         return item.getItemStack();
+    }
+
+    /**
+     * Get the amount of items involved
+     */
+    public int getAmount() {
+        return amount;
     }
 
     /**

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
@@ -20,8 +20,6 @@
 
 package com.tomkeuper.bedwars.listeners;
 
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -30,10 +28,6 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.tomkeuper.bedwars.support.version.common.VersionCommon.api;
 import static com.tomkeuper.bedwars.utils.MainUtils.*;
@@ -53,11 +47,7 @@ public class ItemDropPickListener {
         @SuppressWarnings("deprecation")
         @EventHandler
         public void onPickUp(PlayerPickupItemEvent e) {
-            if (managePickup(e.getItem(), e.getPlayer(), getItemsAround(e.getItem()).size())) {
-                e.setCancelled(true);
-                return;
-            }
-            manageGeneratorPickUp(e, e.getPlayer(), e.getItem(), getItemsAround(e.getItem()));
+            if (managePickup(e.getItem(), e.getPlayer(), getItemsAround(e.getItem()).size())) e.setCancelled(true);
         }
     }
 
@@ -74,11 +64,7 @@ public class ItemDropPickListener {
         @EventHandler
         public void onPickup(EntityPickupItemEvent e) {
             if (!(e.getEntity() instanceof Player)) return;
-            if (managePickup(e.getItem(), e.getEntity(), getItemsAround(e.getItem()).size())) {
-                e.setCancelled(true);
-                return;
-            }
-            manageGeneratorPickUp(e, (Player) e.getEntity(), e.getItem(), getItemsAround(e.getItem()));
+            if (managePickup(e.getItem(), e.getEntity(), getItemsAround(e.getItem()).size())) e.setCancelled(true);
         }
     }
 

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
@@ -47,7 +47,7 @@ public class ItemDropPickListener {
         @SuppressWarnings("deprecation")
         @EventHandler
         public void onPickUp(PlayerPickupItemEvent e) {
-            if (managePickup(e.getItem(), e.getPlayer(), getItemsAround(e.getItem()).size())) e.setCancelled(true);
+            if (managePickup(e.getItem(), e.getPlayer(), getSimilarItemsAround(e.getItem()).size())) e.setCancelled(true);
         }
     }
 
@@ -64,7 +64,7 @@ public class ItemDropPickListener {
         @EventHandler
         public void onPickup(EntityPickupItemEvent e) {
             if (!(e.getEntity() instanceof Player)) return;
-            if (managePickup(e.getItem(), e.getEntity(), getItemsAround(e.getItem()).size())) e.setCancelled(true);
+            if (managePickup(e.getItem(), e.getEntity(), getSimilarItemsAround(e.getItem()).size())) e.setCancelled(true);
         }
     }
 

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
@@ -20,15 +20,8 @@
 
 package com.tomkeuper.bedwars.listeners;
 
-import com.tomkeuper.bedwars.api.arena.GameState;
-import com.tomkeuper.bedwars.api.arena.IArena;
-import com.tomkeuper.bedwars.api.events.player.PlayerGeneratorCollectEvent;
-import com.tomkeuper.bedwars.api.server.ServerType;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -38,12 +31,12 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.tomkeuper.bedwars.support.version.common.VersionCommon.api;
+import static com.tomkeuper.bedwars.utils.MainUtils.*;
 
 public class ItemDropPickListener {
 
@@ -60,28 +53,11 @@ public class ItemDropPickListener {
         @SuppressWarnings("deprecation")
         @EventHandler
         public void onPickUp(PlayerPickupItemEvent e) {
-            Player p = e.getPlayer();
-
-            List<Item> items = e.getItem().getNearbyEntities(0.5, 0.5, 0.5).stream()
-                    .filter(entity -> entity instanceof Item)
-                    .filter(entity -> ((Item) entity).getItemStack().getType() == e.getItem().getItemStack().getType())
-                    .filter(entity -> entity.getLocation().distance(e.getItem().getLocation()) < 0.1)
-                    .map(entity -> (Item) entity)
-                    .collect(Collectors.toList());
-            items.add(e.getItem());
-            int amount = items.size();
-
-            if (managePickup(e.getItem(), e.getPlayer(), items.size())) {
+            if (managePickup(e.getItem(), e.getPlayer(), getItemsAround(e.getItem()).size())) {
                 e.setCancelled(true);
                 return;
             }
-
-            if (items.size() > 1) {
-                items.remove(e.getItem());
-                items.forEach(Entity::remove);
-            }
-            if (items.size() == 1) return;
-            p.getInventory().addItem(new ItemStack(e.getItem().getItemStack().getType(), amount));
+            manageGeneratorPickUp(e, e.getPlayer(), e.getItem(), getItemsAround(e.getItem()));
         }
     }
 
@@ -98,29 +74,11 @@ public class ItemDropPickListener {
         @EventHandler
         public void onPickup(EntityPickupItemEvent e) {
             if (!(e.getEntity() instanceof Player)) return;
-            Player p = e.getEntity() instanceof Player ? (Player) e.getEntity() : null;
-            if (p == null) return;
-
-            List<Item> items = e.getItem().getNearbyEntities(0.5, 0.5, 0.5).stream()
-                    .filter(entity -> entity instanceof Item)
-                    .filter(entity -> ((Item) entity).getItemStack().getType() == e.getItem().getItemStack().getType())
-                    .filter(entity -> entity.getLocation().distance(e.getItem().getLocation()) < 0.1)
-                    .map(entity -> (Item) entity)
-                    .collect(Collectors.toList());
-            items.add(e.getItem());
-            int amount = items.size();
-
-            if (managePickup(e.getItem(), e.getEntity(), items.size())) {
+            if (managePickup(e.getItem(), e.getEntity(), getItemsAround(e.getItem()).size())) {
                 e.setCancelled(true);
                 return;
             }
-
-            if (items.size() > 1) {
-                items.remove(e.getItem());
-                items.forEach(Entity::remove);
-            }
-            if (items.size() == 1) return;
-            p.getInventory().addItem(new ItemStack(e.getItem().getItemStack().getType(), amount));
+            manageGeneratorPickUp(e, (Player) e.getEntity(), e.getItem(), getItemsAround(e.getItem()));
         }
     }
 
@@ -132,87 +90,5 @@ public class ItemDropPickListener {
                 e.setCancelled(true);
             }
         }
-    }
-
-    /**
-     * @return true if event should be cancelled
-     */
-    private static boolean managePickup(Item item, LivingEntity player, int amount) {
-        if (!(player instanceof Player)) return false;
-
-        if (api.getServerType() == ServerType.MULTIARENA) {
-            //noinspection ConstantConditions
-            if (player.getLocation().getWorld().getName().equalsIgnoreCase(api.getLobbyWorld())) {
-                return true;
-            }
-        }
-        Player p = (Player) player;
-        IArena a = api.getArenaUtil().getArenaByPlayer(p);
-        ItemStack iStack = item.getItemStack();
-
-        if (a == null) return false;
-        if (!a.isPlayer(p)) return true;
-        if (a.getStatus() != GameState.playing) return true;
-        if (a.getRespawnSessions().containsKey(p)) return true;
-
-        if (iStack.getType() == Material.ARROW) {
-            item.setItemStack(api.getVersionSupport().createItemStack(iStack.getType().toString(), iStack.getAmount(), (short) 0));
-            return false;
-        }
-
-        if (iStack.getType().toString().equals("BED")) {
-            item.remove();
-            return true;
-        } else if (iStack.hasItemMeta()) {
-            //noinspection ConstantConditions
-            if (iStack.getItemMeta().hasDisplayName()) {
-                if (iStack.getItemMeta().getDisplayName().contains("custom")) {
-                    Material material = item.getItemStack().getType();
-                    ItemMeta itemMeta = new ItemStack(material).getItemMeta();
-
-                    //Call ore pick up event
-                    if (!api.getAFKUtil().isPlayerAFK(p)){
-                        PlayerGeneratorCollectEvent event = new PlayerGeneratorCollectEvent(p, item, a, amount);
-                        Bukkit.getPluginManager().callEvent(event);
-                        if (event.isCancelled()) {
-                            return true;
-                        } else {
-                            iStack.setItemMeta(itemMeta);
-                        }
-                    } else return true; //Cancel event if player is afk
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @return true to cancel the event.
-     */
-    private static boolean manageDrop(Entity player, Item item) {
-        if (!(player instanceof Player)) return false;
-        if (api.getServerType() == ServerType.MULTIARENA) {
-            //noinspection ConstantConditions
-            if (player.getLocation().getWorld().getName().equalsIgnoreCase(api.getLobbyWorld())) {
-                return true;
-            }
-        }
-        IArena a = api.getArenaUtil().getArenaByPlayer((Player) player);
-        if (a == null) return false;
-
-        if (!a.isPlayer((Player) player)) {
-            return true;
-        }
-
-        if (a.getStatus() != GameState.playing) {
-            return true;
-        } else {
-            ItemStack i = item.getItemStack();
-            if (i.getType() == Material.COMPASS) {
-                return true;
-            }
-        }
-
-        return a.getRespawnSessions().containsKey(player);
     }
 }

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/PlayerDropPick_1_11Minus.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/PlayerDropPick_1_11Minus.java
@@ -28,7 +28,6 @@ import com.tomkeuper.bedwars.api.server.ServerType;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -39,7 +38,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
-import java.util.stream.Collectors;
+
+import static com.tomkeuper.bedwars.utils.MainUtils.getSimilarItemsAround;
+import static com.tomkeuper.bedwars.utils.MainUtils.manageGeneratorPickUp;
 
 public class PlayerDropPick_1_11Minus implements Listener {
 
@@ -108,26 +109,14 @@ public class PlayerDropPick_1_11Minus implements Listener {
                             e.getItem().setItemStack(stack);
                             Player p = e.getPlayer();
 
-                            List<Item> items = e.getItem().getNearbyEntities(0.5, 0.5, 0.5).stream()
-                                    .filter(entity -> entity instanceof Item)
-                                    .filter(entity -> ((Item) entity).getItemStack().getType() == e.getItem().getItemStack().getType())
-                                    .filter(entity -> entity.getLocation().distance(e.getItem().getLocation()) < 0.1)
-                                    .map(entity -> (Item) entity)
-                                    .collect(Collectors.toList());
+                            List<Item> items = getSimilarItemsAround(e.getItem());
                             items.add(e.getItem());
-                            int amount = items.size();
 
                             if (event.isCancelled()) return;
 
-                            if (items.size() > 1) {
-                                items.remove(e.getItem());
-                                items.forEach(Entity::remove);
-                            }
-                            if (items.size() == 1) return;
-                            p.getInventory().addItem(new ItemStack(e.getItem().getItemStack().getType(), amount));
+                            manageGeneratorPickUp(p, e.getItem(), items);
                         }
-                    }
-                    else {  //Cancel Event if play is afk
+                    } else {  // Cancel Event if play is afk
                         e.setCancelled(true);
                     }
                 }

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/PlayerDropPick_1_11Minus.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/PlayerDropPick_1_11Minus.java
@@ -28,12 +28,18 @@ import com.tomkeuper.bedwars.api.server.ServerType;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PlayerDropPick_1_11Minus implements Listener {
 
@@ -58,6 +64,7 @@ public class PlayerDropPick_1_11Minus implements Listener {
 
         IArena a = api.getArenaUtil().getArenaByPlayer(e.getPlayer());
         if (a == null) return;
+        ItemStack stack = e.getItem().getItemStack();
 
         if (!a.isPlayer(e.getPlayer())) {
             e.setCancelled(true);
@@ -74,30 +81,50 @@ public class PlayerDropPick_1_11Minus implements Listener {
             return;
         }
 
-        if (e.getItem().getItemStack().getType() == Material.ARROW){
-            e.getItem().setItemStack(api.getVersionSupport().createItemStack(e.getItem().getItemStack().getType().toString(), e.getItem().getItemStack().getAmount(), (short) 0));
+        if (stack.getType() == Material.ARROW){
+            e.getItem().setItemStack(api.getVersionSupport().createItemStack(stack.getType().toString(), stack.getAmount(), (short) 0));
             return;
         }
 
-        if (VersionCommon.api.getVersionSupport().isBed(e.getItem().getItemStack().getType())) {
+        if (VersionCommon.api.getVersionSupport().isBed(stack.getType())) {
             e.setCancelled(true);
             e.getItem().remove();
-        } else if (e.getItem().getItemStack().hasItemMeta()) {
+        } else if (stack.hasItemMeta()) {
             //noinspection ConstantConditions
-            if (e.getItem().getItemStack().getItemMeta().hasDisplayName()) {
-                if (e.getItem().getItemStack().getItemMeta().getDisplayName().contains("custom")) {
-                    Material material = e.getItem().getItemStack().getType();
+            if (stack.getItemMeta().hasDisplayName()) {
+                if (stack.getItemMeta().getDisplayName().contains("custom")) {
+                    Material material = stack.getType();
                     ItemMeta itemMeta = new ItemStack(material).getItemMeta();
 
                     //Call ore pick up event
 
                     if (!api.getAFKUtil().isPlayerAFK(e.getPlayer())){
-                        PlayerGeneratorCollectEvent event = new PlayerGeneratorCollectEvent(e.getPlayer(), e.getItem(), a);
+                        PlayerGeneratorCollectEvent event = new PlayerGeneratorCollectEvent(e.getPlayer(), e.getItem(), a, e.getRemaining());
                         Bukkit.getPluginManager().callEvent(event);
                         if (event.isCancelled()){
                             e.setCancelled(true);
                         } else {
-                            e.getItem().getItemStack().setItemMeta(itemMeta);
+                            stack.setItemMeta(itemMeta);
+                            e.getItem().setItemStack(stack);
+                            Player p = e.getPlayer();
+
+                            List<Item> items = e.getItem().getNearbyEntities(0.5, 0.5, 0.5).stream()
+                                    .filter(entity -> entity instanceof Item)
+                                    .filter(entity -> ((Item) entity).getItemStack().getType() == e.getItem().getItemStack().getType())
+                                    .filter(entity -> entity.getLocation().distance(e.getItem().getLocation()) < 0.1)
+                                    .map(entity -> (Item) entity)
+                                    .collect(Collectors.toList());
+                            items.add(e.getItem());
+                            int amount = items.size();
+
+                            if (event.isCancelled()) return;
+
+                            if (items.size() > 1) {
+                                items.remove(e.getItem());
+                                items.forEach(Entity::remove);
+                            }
+                            if (items.size() == 1) return;
+                            p.getInventory().addItem(new ItemStack(e.getItem().getItemStack().getType(), amount));
                         }
                     }
                     else {  //Cancel Event if play is afk

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/shop/defaultrestore/ShopItemRestoreListener.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/shop/defaultrestore/ShopItemRestoreListener.java
@@ -55,7 +55,7 @@ public class ShopItemRestoreListener {
     public static class PlayerPickup implements Listener {
         @SuppressWarnings("deprecation")
         @EventHandler
-        public void onDrop(PlayerPickupItemEvent e) {
+        public void onPickup(PlayerPickupItemEvent e) {
             if (managePickup(e.getItem(), e.getPlayer())) e.setCancelled(true);
         }
     }

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
@@ -41,7 +41,8 @@ public class MainUtils {
         }
         // If the amount is 1, then the player is already picking up the item, so we don't need to add it to their inventory again.
         if (amount == 1) return;
-        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), amount));
+        // We add the item to the player's inventory and remove 1 from the amount to account for the item that is already being picked up.
+        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), amount-1));
     }
 
     /**

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
@@ -1,0 +1,138 @@
+package com.tomkeuper.bedwars.utils;
+
+import com.tomkeuper.bedwars.api.arena.GameState;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.events.player.PlayerGeneratorCollectEvent;
+import com.tomkeuper.bedwars.api.server.ServerType;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.tomkeuper.bedwars.support.version.common.VersionCommon.api;
+
+public class MainUtils {
+    public static List<Item> getItemsAround(Item item) {
+        List<Item> items = item.getNearbyEntities(0.5, 0.5, 0.5).stream()
+                .filter(entity -> entity instanceof Item)
+                .filter(entity -> ((Item) entity).getItemStack().getType() == item.getItemStack().getType())
+                .filter(entity -> entity.getLocation().distance(item.getLocation()) < 0.1)
+                .map(entity -> (Item) entity)
+                .collect(Collectors.toList());
+        items.add(item);
+        return items;
+    }
+
+    public static void manageGeneratorPickUp(PlayerPickupItemEvent e, Player player, Item item, List<Item> items) {
+        int am = items.size();
+
+        if (items.size() > 1) {
+            items.remove(item);
+            items.forEach(Entity::remove);
+        }
+        if (am == 1) return;
+        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), am));
+    }
+
+    public static void manageGeneratorPickUp(EntityPickupItemEvent e, Player player, Item item, List<Item> items) {
+        int am = items.size();
+
+        if (items.size() > 1) {
+            items.remove(item);
+            items.forEach(Entity::remove);
+        }
+        if (am == 1) return;
+        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), am));
+    }
+
+    /**
+     * @return true if event should be cancelled
+     */
+    public static boolean managePickup(Item item, LivingEntity player, int amount) {
+        if (!(player instanceof Player)) return false;
+
+        if (api.getServerType() == ServerType.MULTIARENA) {
+            //noinspection ConstantConditions
+            if (player.getLocation().getWorld().getName().equalsIgnoreCase(api.getLobbyWorld())) {
+                return true;
+            }
+        }
+        Player p = (Player) player;
+        IArena a = api.getArenaUtil().getArenaByPlayer(p);
+        ItemStack iStack = item.getItemStack();
+
+        if (a == null) return false;
+        if (!a.isPlayer(p)) return true;
+        if (a.getStatus() != GameState.playing) return true;
+        if (a.getRespawnSessions().containsKey(p)) return true;
+
+        if (iStack.getType() == Material.ARROW) {
+            item.setItemStack(api.getVersionSupport().createItemStack(iStack.getType().toString(), iStack.getAmount(), (short) 0));
+            return false;
+        }
+
+        if (iStack.getType().toString().equals("BED")) {
+            item.remove();
+            return true;
+        } else if (iStack.hasItemMeta()) {
+            //noinspection ConstantConditions
+            if (iStack.getItemMeta().hasDisplayName()) {
+                if (iStack.getItemMeta().getDisplayName().contains("custom")) {
+                    Material material = item.getItemStack().getType();
+                    ItemMeta itemMeta = new ItemStack(material).getItemMeta();
+
+                    //Call ore pick up event
+                    if (!api.getAFKUtil().isPlayerAFK(p)){
+                        PlayerGeneratorCollectEvent event = new PlayerGeneratorCollectEvent(p, item, a, amount);
+                        Bukkit.getPluginManager().callEvent(event);
+                        if (event.isCancelled()) {
+                            return true;
+                        } else {
+                            iStack.setItemMeta(itemMeta);
+                        }
+                    } else return true; //Cancel event if player is afk
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true to cancel the event.
+     */
+    public static boolean manageDrop(Entity player, Item item) {
+        if (!(player instanceof Player)) return false;
+        if (api.getServerType() == ServerType.MULTIARENA) {
+            //noinspection ConstantConditions
+            if (player.getLocation().getWorld().getName().equalsIgnoreCase(api.getLobbyWorld())) {
+                return true;
+            }
+        }
+        IArena a = api.getArenaUtil().getArenaByPlayer((Player) player);
+        if (a == null) return false;
+
+        if (!a.isPlayer((Player) player)) {
+            return true;
+        }
+
+        if (a.getStatus() != GameState.playing) {
+            return true;
+        } else {
+            ItemStack i = item.getItemStack();
+            if (i.getType() == Material.COMPASS) {
+                return true;
+            }
+        }
+
+        return a.getRespawnSessions().containsKey(player);
+    }
+}

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
@@ -10,8 +10,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityPickupItemEvent;
-import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -32,26 +30,18 @@ public class MainUtils {
         return items;
     }
 
-    public static void manageGeneratorPickUp(PlayerPickupItemEvent e, Player player, Item item, List<Item> items) {
-        int am = items.size();
+    public static void manageGeneratorPickUp(Player player, Item item, List<Item> items) {
+        int amount = items.size();
 
         if (items.size() > 1) {
+            // We remove the item that is being picked up from the list.
             items.remove(item);
+            // We remove the entities to prevent more than one item from being picked up.
             items.forEach(Entity::remove);
         }
-        if (am == 1) return;
-        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), am));
-    }
-
-    public static void manageGeneratorPickUp(EntityPickupItemEvent e, Player player, Item item, List<Item> items) {
-        int am = items.size();
-
-        if (items.size() > 1) {
-            items.remove(item);
-            items.forEach(Entity::remove);
-        }
-        if (am == 1) return;
-        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), am));
+        // If the amount is 1, then the player is already picking up the item, so we don't need to add it to their inventory again.
+        if (amount == 1) return;
+        player.getInventory().addItem(new ItemStack(item.getItemStack().getType(), amount));
     }
 
     /**
@@ -98,8 +88,9 @@ public class MainUtils {
                             return true;
                         } else {
                             iStack.setItemMeta(itemMeta);
+                            manageGeneratorPickUp(p, item, getItemsAround(item));
                         }
-                    } else return true; //Cancel event if player is afk
+                    } else return true; // Cancel event if player is afk
                 }
             }
         }

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
 import static com.tomkeuper.bedwars.support.version.common.VersionCommon.api;
 
 public class MainUtils {
-    public static List<Item> getItemsAround(Item item) {
+    public static List<Item> getSimilarItemsAround(Item item) {
+        // We get all the items around the item that are of the same type.
         List<Item> items = item.getNearbyEntities(0.5, 0.5, 0.5).stream()
                 .filter(entity -> entity instanceof Item)
                 .filter(entity -> ((Item) entity).getItemStack().getType() == item.getItemStack().getType())
@@ -33,7 +34,7 @@ public class MainUtils {
     public static void manageGeneratorPickUp(Player player, Item item, List<Item> items) {
         int amount = items.size();
 
-        if (items.size() > 1) {
+        if (amount > 1) {
             // We remove the item that is being picked up from the list.
             items.remove(item);
             // We remove the entities to prevent more than one item from being picked up.
@@ -89,7 +90,7 @@ public class MainUtils {
                             return true;
                         } else {
                             iStack.setItemMeta(itemMeta);
-                            manageGeneratorPickUp(p, item, getItemsAround(item));
+                            manageGeneratorPickUp(p, item, getSimilarItemsAround(item));
                         }
                     } else return true; // Cancel event if player is afk
                 }


### PR DESCRIPTION
This makes when picking up a lot of items from generators the server to not lag, the old method produced a big lag spike because of the events called when picking up a lot of items