### PR TITLE
Simple shop and upgrades right click fix for 1.7

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/listeners/ShopOpenListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/listeners/ShopOpenListener.java
@@ -29,12 +29,12 @@ import com.tomkeuper.bedwars.shop.quickbuy.PlayerQuickBuyCache;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public class ShopOpenListener implements Listener {
 
     @EventHandler
-    public void onShopOpen(PlayerInteractAtEntityEvent e){
+    public void onShopOpen(PlayerInteractEntityEvent e){
         IArena a = Arena.getArenaByPlayer(e.getPlayer());
         if (a == null) return;
         if(!a.getStatus().equals(GameState.playing)) return;

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/listeners/UpgradeOpenListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/listeners/UpgradeOpenListener.java
@@ -29,12 +29,12 @@ import com.tomkeuper.bedwars.upgrades.UpgradesManager;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 public class UpgradeOpenListener implements Listener {
 
     @EventHandler
-    public void onUpgradesOpen(PlayerInteractAtEntityEvent e){
+    public void onUpgradesOpen(PlayerInteractEntityEvent e){
         IArena a = Arena.getArenaByPlayer(e.getPlayer());
         if (a == null) return;
         if(!a.getStatus().equals(GameState.playing)) return;


### PR DESCRIPTION
This simple fix just replace PlayerInteractAtEntityEvent with PlayerInteractEntityEvent which in this case doesn't make a difference otherwise. It just works with ViaRewind. I've tested this on 1.8.8, 1.12.2, and 1.18.2 and all seems good. Thoughts on should it be in the main plugin or a fork?