### PR TITLE
Fixes in VersionSupport inheritors

### DIFF
--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -735,7 +735,7 @@ public class v1_12_R1 extends VersionSupport {
         b.getRelative(x, y, z).setType(Material.WOOL);
         setBlockTeamColor(b.getRelative(x, y, z), color);
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override
@@ -743,7 +743,7 @@ public class v1_12_R1 extends VersionSupport {
         b.getRelative(x, y, z).setType(Material.LADDER);
         b.getRelative(x, y, z).setData((byte)ladderdata);
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -779,7 +779,7 @@ public class v1_8_R3 extends VersionSupport {
         b.getRelative(x, y, z).setType(Material.WOOL);
         setBlockTeamColor(b.getRelative(x, y, z), color);
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override
@@ -787,7 +787,7 @@ public class v1_8_R3 extends VersionSupport {
         b.getRelative(x, y, z).setType(Material.LADDER);
         b.getRelative(x, y, z).setData((byte)ladderdata);
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
 

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -717,7 +717,7 @@ public class v1_16_R3 extends VersionSupport {
     public Block placeTowerBlocks(Block b, IArena a, TeamColor color, int x, int y,int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -752,7 +752,7 @@ public class v1_17_R1 extends VersionSupport {
     public Block placeTowerBlocks(Block b, IArena a, TeamColor color, int x, int y,int z) {
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -723,7 +723,7 @@ public class v1_18_R2 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
@@ -834,7 +834,7 @@ public class v1_19_R3 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_20_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R1/v1_20_R1.java
+++ b/versionsupport_v1_20_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R1/v1_20_R1.java
@@ -829,7 +829,7 @@ public class v1_20_R1 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_20_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R2/v1_20_R2.java
+++ b/versionsupport_v1_20_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R2/v1_20_R2.java
@@ -832,7 +832,7 @@ public class v1_20_R2 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_20_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R3/v1_20_R3.java
+++ b/versionsupport_v1_20_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R3/v1_20_R3.java
@@ -831,7 +831,7 @@ public class v1_20_R3 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -715,7 +715,7 @@ public final class v1_20_R4 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z){
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -716,7 +716,7 @@ public final class v1_21_R1 extends VersionSupport {
     public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
         b.getRelative(x, y, z).setType(color.woolMaterial());
         a.addPlacedBlock(b.getRelative(x, y, z));
-        return b;
+        return b.getRelative(x, y, z);
     }
 
     @Override


### PR DESCRIPTION
Fixed VersionSupport#placeTowerBlock, where the return of it (Block) would return the same block in the centre and not the relative ones