### PR TITLE
Remove NBT Identifier from normal items

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
@@ -385,16 +385,6 @@ public class BreakPlace implements Listener {
                     e.setCancelled(true);
                 }
             }
-
-            if (!e.isCancelled() && p.getGameMode() != GameMode.CREATIVE){
-                Block drop = e.getBlock();
-                Collection<ItemStack> drops = drop.getDrops(e.getPlayer().getItemInHand());
-                drop.setType(Material.AIR);
-                for (ItemStack item : drops){
-                    ItemStack newItem = nms.addCustomData(item, "");
-                    e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation().add(0.5,0.5,0.5), newItem);
-                }
-            }
         }
     }
 
@@ -530,27 +520,6 @@ public class BreakPlace implements Listener {
         if (a != null) {
             if (a.getStatus() == GameState.playing) {
                 e.blockList().removeIf((b) -> (a.isProtected(b.getLocation()) || a.isTeamBed(b.getLocation()) || (!a.isBlockPlaced(b) && !a.isAllowMapBreak())));
-                // Process the remaining blocks to add custom data to the drops
-                for (Block block : e.blockList()) {
-                    // Get the original drops
-                    List<ItemStack> drops = new ArrayList<>(block.getDrops());
-
-                    // Clear the block drops to prevent them from being dropped automatically
-                    e.setYield(0);
-
-                    List<ItemStack> modifiedDrops = new ArrayList<>();
-
-                    for (ItemStack drop : drops) {
-                        // Add custom data to each drop using the provided function
-                        ItemStack modifiedDrop = nms.addCustomData(drop, ""); // replace "custom_nbt_data" with the actual data you want to add
-                        modifiedDrops.add(modifiedDrop);
-                    }
-
-                    // Drop only the modified items at the block location
-                    for (ItemStack modifiedDrop : modifiedDrops) {
-                        block.getWorld().dropItemNaturally(block.getLocation(), modifiedDrop);
-                    }
-                }
             }
         }
     }
@@ -564,27 +533,6 @@ public class BreakPlace implements Listener {
         if (a != null) {
             if (a.getStatus() == GameState.playing) {
                 e.blockList().removeIf((b) -> (a.isProtected(b.getLocation()) || a.isTeamBed(b.getLocation()) || (!a.isBlockPlaced(b) && !a.isAllowMapBreak())));
-                // Process the remaining blocks to add custom data to the drops
-                for (Block block : e.blockList()) {
-                    // Get the original drops
-                    List<ItemStack> drops = new ArrayList<>(block.getDrops());
-
-                    // Clear the block drops to prevent them from being dropped automatically
-                    e.setYield(0);
-
-                    List<ItemStack> modifiedDrops = new ArrayList<>();
-
-                    for (ItemStack drop : drops) {
-                        // Add custom data to each drop using the provided function
-                        ItemStack modifiedDrop = nms.addCustomData(drop, ""); // replace "custom_nbt_data" with the actual data you want to add
-                        modifiedDrops.add(modifiedDrop);
-                    }
-
-                    // Drop only the modified items at the block location
-                    for (ItemStack modifiedDrop : modifiedDrops) {
-                        block.getWorld().dropItemNaturally(block.getLocation(), modifiedDrop);
-                    }
-                }
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
@@ -530,7 +530,27 @@ public class BreakPlace implements Listener {
         if (a != null) {
             if (a.getStatus() == GameState.playing) {
                 e.blockList().removeIf((b) -> (a.isProtected(b.getLocation()) || a.isTeamBed(b.getLocation()) || (!a.isBlockPlaced(b) && !a.isAllowMapBreak())));
-                return;
+                // Process the remaining blocks to add custom data to the drops
+                for (Block block : e.blockList()) {
+                    // Get the original drops
+                    List<ItemStack> drops = new ArrayList<>(block.getDrops());
+
+                    // Clear the block drops to prevent them from being dropped automatically
+                    e.setYield(0);
+
+                    List<ItemStack> modifiedDrops = new ArrayList<>();
+
+                    for (ItemStack drop : drops) {
+                        // Add custom data to each drop using the provided function
+                        ItemStack modifiedDrop = nms.addCustomData(drop, ""); // replace "custom_nbt_data" with the actual data you want to add
+                        modifiedDrops.add(modifiedDrop);
+                    }
+
+                    // Drop only the modified items at the block location
+                    for (ItemStack modifiedDrop : modifiedDrops) {
+                        block.getWorld().dropItemNaturally(block.getLocation(), modifiedDrop);
+                    }
+                }
             }
         }
     }
@@ -544,6 +564,27 @@ public class BreakPlace implements Listener {
         if (a != null) {
             if (a.getStatus() == GameState.playing) {
                 e.blockList().removeIf((b) -> (a.isProtected(b.getLocation()) || a.isTeamBed(b.getLocation()) || (!a.isBlockPlaced(b) && !a.isAllowMapBreak())));
+                // Process the remaining blocks to add custom data to the drops
+                for (Block block : e.blockList()) {
+                    // Get the original drops
+                    List<ItemStack> drops = new ArrayList<>(block.getDrops());
+
+                    // Clear the block drops to prevent them from being dropped automatically
+                    e.setYield(0);
+
+                    List<ItemStack> modifiedDrops = new ArrayList<>();
+
+                    for (ItemStack drop : drops) {
+                        // Add custom data to each drop using the provided function
+                        ItemStack modifiedDrop = nms.addCustomData(drop, ""); // replace "custom_nbt_data" with the actual data you want to add
+                        modifiedDrops.add(modifiedDrop);
+                    }
+
+                    // Drop only the modified items at the block location
+                    for (ItemStack modifiedDrop : modifiedDrops) {
+                        block.getWorld().dropItemNaturally(block.getLocation(), modifiedDrop);
+                    }
+                }
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/main/BuyItem.java
@@ -174,14 +174,12 @@ public class BuyItem implements IBuyItem {
     public void give(Player player, IArena arena) {
 
         ItemStack i = itemStack.clone();
-        i = BedWars.nms.addCustomData(i,"");
         BedWars.debug("Giving BuyItem: " + getUpgradeIdentifier() + " to: " + player.getName());
 
         if (autoEquip && BedWars.nms.isArmor(itemStack)) {
             Material m = i.getType();
 
             ItemMeta im = i.getItemMeta();
-            // idk dadea erori
             if (arena.getTeam(player) == null) {
                 BedWars.debug("Could not give BuyItem to " + player.getName() + " - TEAM IS NULL");
                 return;

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -383,7 +383,7 @@ public class v1_12_R1 extends VersionSupport {
             tag = new NBTTagCompound();
         }
 
-        tag.setString("BedWars2023", data);
+        tag.setString(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
         itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
@@ -406,7 +406,7 @@ public class v1_12_R1 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return false;
-        return tag.hasKey("BedWars2023");
+        return tag.hasKey(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override
@@ -414,7 +414,7 @@ public class v1_12_R1 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return "";
-        return tag.getString("BedWars2023");
+        return tag.getString(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -449,7 +449,7 @@ public class v1_8_R3 extends VersionSupport {
             tag = new NBTTagCompound();
         }
 
-        tag.setString("BedWars2023", data);
+        tag.setString(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
         itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
@@ -480,7 +480,7 @@ public class v1_8_R3 extends VersionSupport {
         if (itemStack == null) return false;
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return false;
-        return tag.hasKey("BedWars2023");
+        return tag.hasKey(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override
@@ -488,7 +488,7 @@ public class v1_8_R3 extends VersionSupport {
         net.minecraft.server.v1_8_R3.ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return "";
-        return tag.getString("BedWars2023");
+        return tag.getString(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/listeners/ItemDropPickListener.java
@@ -20,6 +20,9 @@
 
 package com.tomkeuper.bedwars.listeners;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -28,6 +31,7 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
 
 import static com.tomkeuper.bedwars.support.version.common.VersionCommon.api;
 import static com.tomkeuper.bedwars.utils.MainUtils.*;
@@ -72,6 +76,7 @@ public class ItemDropPickListener {
     public static class ArrowCollect implements Listener {
         @EventHandler
         public void onArrowPick(PlayerPickupArrowEvent e){
+            Bukkit.getLogger().info("onArrowPick");
             if (api.getArenaUtil().isSpectating(e.getPlayer())) {
                 e.setCancelled(true);
             }

--- a/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
+++ b/versionsupport_common/src/main/java/com/tomkeuper/bedwars/utils/MainUtils.java
@@ -82,8 +82,8 @@ public class MainUtils {
                     Material material = item.getItemStack().getType();
                     ItemMeta itemMeta = new ItemStack(material).getItemMeta();
 
-                    //Call ore pick up event
-                    if (!api.getAFKUtil().isPlayerAFK(p)){
+                    // Call ore pick up event
+                    if (!api.getAFKUtil().isPlayerAFK(p)) {
                         PlayerGeneratorCollectEvent event = new PlayerGeneratorCollectEvent(p, item, a, amount);
                         Bukkit.getPluginManager().callEvent(event);
                         if (event.isCancelled()) {

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -383,7 +383,7 @@ public class v1_16_R3 extends VersionSupport {
             tag = new NBTTagCompound();
         }
 
-        tag.setString("BedWars2023", data);
+        tag.setString(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
         itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
@@ -406,7 +406,7 @@ public class v1_16_R3 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return false;
-        return tag.hasKey("BedWars2023");
+        return tag.hasKey(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override
@@ -414,7 +414,7 @@ public class v1_16_R3 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return "";
-        return tag.getString("BedWars2023");
+        return tag.getString(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -413,7 +413,7 @@ public class v1_17_R1 extends VersionSupport {
             tag = new NBTTagCompound();
         }
 
-        tag.setString("BedWars2023", data);
+        tag.setString(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
         itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
@@ -436,7 +436,7 @@ public class v1_17_R1 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return false;
-        return tag.hasKey("BedWars2023");
+        return tag.hasKey(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override
@@ -444,7 +444,7 @@ public class v1_17_R1 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) return "";
-        return tag.getString("BedWars2023");
+        return tag.getString(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -398,7 +398,7 @@ public class v1_18_R2 extends VersionSupport {
             itemStack.c(tag);
         }
 
-        tag.a("BedWars2023", data);
+        tag.a(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -420,7 +420,7 @@ public class v1_18_R2 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.t();
         if (tag == null) return false;
-        return tag.e("BedWars2023");
+        return tag.e(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override
@@ -428,7 +428,7 @@ public class v1_18_R2 extends VersionSupport {
         ItemStack itemStack = CraftItemStack.asNMSCopy(i);
         NBTTagCompound tag = itemStack.t();
         if (tag == null) return "";
-        return tag.l("BedWars2023");
+        return tag.l(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
     }
 
     @Override


### PR DESCRIPTION
Solves arrows also not being able to stack. Other solution was to exclude arrows from the NBT identifier, but this is a dirty fix.
After concidering what the NBT tag is actually used for, I decided to remove it from normal items