### PR TITLE
Dragon can now destroy protected blocks

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/IArena.java
@@ -735,4 +735,20 @@ public interface IArena {
      * @return The team that owns the bed at the given location, or null if there is no bed or if the location is not in this arena's world.
      */
     @Nullable ITeam getBedsTeam(Location location);
+
+    /**
+     * Enable or disable the ender dragon from destroying blocks even when protected.
+     *
+     * @return true if the ender dragon can destroy blocks, false otherwise.
+     */
+    boolean isAllowEnderDragonDestroy();
+
+    /**
+     * Enable or disable the ender dragon from destroying blocks even when protected.
+     *
+     * @param allowDestory true if the ender dragon can destroy blocks, false otherwise.
+     */
+    @SuppressWarnings("unused")
+    void setAllowEnderDragonDestroy(boolean allowDestory);
+
 }

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -198,6 +198,7 @@ public class ConfigPath {
     public static final String ARENA_NORMAL_DEATH_DROPS = "vanilla-death-drops";
     public static final String ARENA_USE_BED_HOLO = "use-bed-hologram";
     public static final String ARENA_ALLOW_MAP_BREAK = "allow-map-break";
+    public static final String ARENA_ALLOW_DRAGON_DESTROY_WHEN_PROTECTED = "allow-dragon-destroy-when-protected";
     public static final String ARENA_GAME_RULES = "game-rules";
     public static final String ARENA_SPEC_LOC = "spectator-loc";
     public static final String ARENA_TEAM_KILL_DROPS_LOC = "kill-drops-loc";

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -121,7 +121,7 @@ public class Arena implements IArena {
     private ArenaConfig cm;
     private int minPlayers = 2, maxPlayers = 10, maxInTeam = 1, islandRadius = 10;
     public int upgradeDiamondsCount = 0, upgradeEmeraldsCount = 0;
-    public boolean allowSpectate = true, allowMapBreak = false;
+    public boolean allowSpectate = true, allowMapBreak = false, enderDragonDestory = false;
     private World world;
     private String group = "Default", arenaName, worldName;
     private List<ITeam> teams = new ArrayList<>();
@@ -238,6 +238,7 @@ public class Arena implements IArena {
         minPlayers = yml.getInt("minPlayers");
         allowSpectate = yml.getBoolean("allowSpectate");
         allowMapBreak = yml.getBoolean("allow-map-break");
+        enderDragonDestory = yml.getBoolean(ConfigPath.ARENA_ALLOW_DRAGON_DESTROY_WHEN_PROTECTED);
         islandRadius = yml.getInt(ConfigPath.ARENA_ISLAND_RADIUS);
         if (config.getYml().get("arenaGroups") != null) {
             if (config.getYml().getStringList("arenaGroups").contains(yml.getString("group"))) {
@@ -2515,6 +2516,16 @@ public class Arena implements IArena {
             }
         }
         return null;
+    }
+
+    @Override
+    public boolean isAllowEnderDragonDestroy() {
+        return enderDragonDestory;
+    }
+
+    @Override
+    public void setAllowEnderDragonDestroy(boolean allowDestory) {
+        this.enderDragonDestory = allowDestory;
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
@@ -55,6 +55,7 @@ public class ArenaConfig extends ConfigManager {
         yml.addDefault(ConfigPath.ARENA_NORMAL_DEATH_DROPS, false);
         yml.addDefault(ConfigPath.ARENA_USE_BED_HOLO, true);
         yml.addDefault(ConfigPath.ARENA_ALLOW_MAP_BREAK, false);
+        yml.addDefault(ConfigPath.ARENA_ALLOW_DRAGON_DESTROY_WHEN_PROTECTED, true);
         ArrayList<String> rules = new ArrayList<>();
         rules.add("doDaylightCycle:false");
         rules.add("announceAdvancements:false");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
@@ -519,6 +519,9 @@ public class BreakPlace implements Listener {
         IArena a = Arena.getArenaByIdentifier(e.getLocation().getWorld().getName());
         if (a != null) {
             if (a.getStatus() == GameState.playing) {
+                if (e.getEntity().getType() == EntityType.ENDER_DRAGON && a.isAllowEnderDragonDestroy()) {
+                    return;
+                }
                 e.blockList().removeIf((b) -> (a.isProtected(b.getLocation()) || a.isTeamBed(b.getLocation()) || (!a.isBlockPlaced(b) && !a.isAllowMapBreak())));
             }
         }


### PR DESCRIPTION
configurable in arena config `allow-dragon-destroy-when-protected`

requires #319 