### PR TITLE
Full customization of the spectator menu.

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -106,6 +106,11 @@ public class ConfigPath {
     public static final String GENERAL_CONFIGURATION_STATS_ITEMS_DATA = GENERAL_CONFIGURATION_STATS_PATH + ".%path%.data";
     public static final String GENERAL_CONFIGURATION_STATS_ITEMS_SLOT = GENERAL_CONFIGURATION_STATS_PATH + ".%path%.slot";
 
+    public static final String GENERAL_CONFIGURATION_TELEPORTER_PATH = "teleporter-gui";
+    public static final String GENERAL_CONFIGURATION_TELEPORTER_SETTINGS_PATH = GENERAL_CONFIGURATION_TELEPORTER_PATH + ".settings";
+    public static final String GENERAL_CONFIGURATION_TELEPORTER_GUI_SIZE = GENERAL_CONFIGURATION_TELEPORTER_SETTINGS_PATH + ".inv-size";
+    public static final String GENERAL_CONFIGURATION_TELEPORTER_SLOTS = GENERAL_CONFIGURATION_TELEPORTER_SETTINGS_PATH + ".use-slots";
+
     public static final String GENERAL_CONFIGURATION_PRE_GAME_ITEMS_PATH = "pre-game-items";
     // Replace %path% with name
     public static final String GENERAL_CONFIGURATION_PRE_GAME_ITEMS_MATERIAL = GENERAL_CONFIGURATION_PRE_GAME_ITEMS_PATH + ".%path%.material";

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
@@ -129,7 +129,7 @@ public class TeleporterGUI {
                 .replace("%bw_v_suffix%", BedWars.getChatSupport().getSuffix(targetPlayer))
                 .replace("%bw_player%", targetPlayer.getDisplayName())
                 .replace("%bw_team_color%", String.valueOf(targetPlayerTeam.getColor().chat()))
-                .replace("%bw_team%", targetPlayerTeam.getDisplayName(Language.getPlayerLanguage(player)))
+                .replace("%bw_team%", targetPlayerTeam.getDisplayName(Language.getPlayerLanguage(GUIholder)))
                 .replace("%bw_playername%", targetPlayer.getName()));
         List<String> lore = new ArrayList<>();
         String health = String.valueOf((int)targetPlayer.getHealth() * 100 / targetPlayer.getHealthScale());

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
@@ -117,7 +117,7 @@ public class TeleporterGUI {
     /**
      * Create a player head
      */
-    private static ItemStack createHead(Player targetPlayer, Player player) {
+    private static ItemStack createHead(Player targetPlayer, Player GUIholder) {
         ItemStack i = nms.getPlayerHead(targetPlayer, null);
         ItemMeta im = i.getItemMeta();
         assert im != null;
@@ -133,7 +133,7 @@ public class TeleporterGUI {
                 .replace("%bw_playername%", targetPlayer.getName()));
         List<String> lore = new ArrayList<>();
         String health = String.valueOf((int)targetPlayer.getHealth() * 100 / targetPlayer.getHealthScale());
-        for (String s : getList(player, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_HEAD_LORE)) {
+        for (String s : getList(GUIholder, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_HEAD_LORE)) {
             lore.add(s.replace("%bw_player_health%", health).replace("%bw_player_food%", String.valueOf(targetPlayer.getFoodLevel())));
         }
         im.setLore(lore);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -197,6 +197,10 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_ARENA_SELECTOR_STATUS_DATA.replace("%path%", "skipped-slot"), 15);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_ARENA_SELECTOR_STATUS_ENCHANTED.replace("%path%", "skipped-slot"), false);
 
+        /* default teleporter GUI settings */
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_TELEPORTER_GUI_SIZE, 36);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_TELEPORTER_SLOTS, "10,11,12,13,14,15,16,19,20,21,22,23,24,25");
+
         /* default stats GUI items */
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_STATS_GUI_SIZE, 27);
         if (isFirstTime()) {


### PR DESCRIPTION
## Modifications
- **New Paths in `MainConfig`**:
  - Customization for inventory size and slot usage.
- **Added Options**:
  - New settings in `MainConfig` to control the spectator menu.
- **System Implementation**:
  - Fully integrated into the `TeleporterGUI` class.

## Configuration Example
To customize the Teleporter GUI, use the following configuration in `MainConfig.yml`:

```yaml
teleporter-gui:
  settings:
    inv-size: 36
    use-slots: 10,11,12,13,14,15,16
```

## Notes
- If `inv-size` is not a valid multiple of 9 or exceeds 54, defaults will be applied.
- Any invalid or out-of-range slot numbers in `use-slots` will be ignored.