### PR TITLE
Add initial version support for 1.21 R2 and 1.21 R3

### DIFF
--- a/bedwars-plugin/build.gradle.kts
+++ b/bedwars-plugin/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     api(projects.versionsupportV120R3)
     api(projects.versionsupportV120R4)
     api(projects.versionsupportV121R1)
+    api(projects.versionsupportV121R2)
+    api(projects.versionsupportV121R3)
 
     api("com.andrei1058.vipfeatures:vipfeatures-api:[1.0,)")
     api("com.zaxxer:HikariCP:5.0.1") {
@@ -134,6 +136,8 @@ val versions = setOf(
     projects.versionsupportV120R3,
     projects.versionsupportV120R4,
     projects.versionsupportV121R1,
+    projects.versionsupportV121R2,
+    projects.versionsupportV121R3,
     projects.resetadapterSlime,
     projects.resetadapterSlimepaper,
     projects.resetadapterAswm

--- a/bedwars-plugin/build.gradle.kts
+++ b/bedwars-plugin/build.gradle.kts
@@ -79,10 +79,10 @@ dependencies {
     compileOnly("de.dytanic.cloudnet:cloudnet-wrapper-jvm:3.4.5-RELEASE")
     slim("redis.clients:jedis:5.0.2")
     slim("com.flowpowered:flow-nbt:2.0.2")
-    slim("com.saicone.rtag:rtag:1.5.4")
-    slim("com.saicone.rtag:rtag-block:1.5.4")
-    slim("com.saicone.rtag:rtag-entity:1.5.4")
-    slim("com.saicone.rtag:rtag-item:1.5.4")
+    slim("com.saicone.rtag:rtag:1.5.9")
+    slim("com.saicone.rtag:rtag-block:1.5.9")
+    slim("com.saicone.rtag:rtag-entity:1.5.9")
+    slim("com.saicone.rtag:rtag-item:1.5.9")
 }
 
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -233,6 +233,13 @@ public class BedWars extends JavaPlugin {
             case "1.21.1":
                 nmsVersion = "v1_21_R1";
                 break;
+            case "1.21.3":
+            case "1.21.2":
+                nmsVersion = "v1_21_R2";
+                break;
+            case "1.21.4":
+                nmsVersion = "v1_21_R3";
+                break;
             default:
                 break;
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ val versions = setOf(
     projects.versionsupportV120R3,
     projects.versionsupportV120R4,
     projects.versionsupportV121R1,
+    projects.versionsupportV121R2,
+    projects.versionsupportV121R3,
     projects.resetadapterSlime,
     projects.resetadapterSlimepaper,
     projects.bedwarsApi,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,8 @@ include(":versionsupport_v1_20_r2")
 include(":versionsupport_v1_20_r3")
 include(":versionsupport_v1_20_r4")
 include(":versionsupport_v1_21_r1")
+include(":versionsupport_v1_21_r2")
+include(":versionsupport_v1_21_r3")
 include(":versionsupport_common")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/versionsupport_v1_20_r4/build.gradle.kts
+++ b/versionsupport_v1_20_r4/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.20.5-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    compileOnly("com.saicone.rtag:rtag:1.5.9")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.9")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r1/build.gradle.kts
+++ b/versionsupport_v1_21_r1/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.21.1-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    compileOnly("com.saicone.rtag:rtag:1.5.9")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.9")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/DefaultGenAnimation.java
@@ -32,10 +32,6 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-/**
- * @author Lagggpixel
- * @since May 10, 2024
- */
 public class DefaultGenAnimation implements IGeneratorAnimation {
 
     private final Entity armorStand;

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -56,7 +56,6 @@ import net.minecraft.world.entity.EntityLiving;
 import net.minecraft.world.entity.EnumItemSlot;
 import net.minecraft.world.entity.decoration.EntityArmorStand;
 import net.minecraft.world.entity.item.EntityTNTPrimed;
-import net.minecraft.world.entity.projectile.EntityFireball;
 import net.minecraft.world.entity.projectile.IProjectile;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.*;

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -419,6 +419,8 @@ public final class v1_21_R1 extends VersionSupport {
 
     @Override
     public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        if (i == null) return false;
+        if (i.getType() == org.bukkit.Material.AIR) return false;
         RtagItem rtagItem = new RtagItem(i);
         OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
         return tag.isNotEmpty();

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -816,7 +816,7 @@ public final class v1_21_R1 extends VersionSupport {
             throw new RuntimeException("World of a location should not be null.");
         }
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
-        nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
         for (Player p : loc.getWorld().getPlayers()) {

--- a/versionsupport_v1_21_r2/build.gradle.kts
+++ b/versionsupport_v1_21_r2/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.21.3-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    compileOnly("com.saicone.rtag:rtag:1.5.9")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.9")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r2/build.gradle.kts
+++ b/versionsupport_v1_21_r2/build.gradle.kts
@@ -1,0 +1,27 @@
+dependencies {
+    compileOnly(projects.bedwarsApi)
+    implementation(projects.versionsupportCommon)
+    compileOnly("org.spigotmc:spigot:1.21.3-R0.1-SNAPSHOT") {
+        exclude("commons-lang", "commons-lang")
+    }
+    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    // Other modules
+    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+}
+
+tasks.compileJava {
+    options.release.set(21)
+}
+
+repositories {
+    // Important Repos
+    mavenCentral()
+    mavenLocal()
+    maven("https://repo.codemc.io/repository/nms/") // Spigot
+    maven("https://repo.papermc.io/repository/maven-public/") // com.mojang (dep of Spigot)
+    maven("https://jitpack.io") // Jitpack (RTag)
+}
+
+description = "versionsupport_v1_21_r2"

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -25,6 +25,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutEntity;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -32,6 +33,9 @@ import org.bukkit.craftbukkit.v1_21_R2.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Lagggpixel
@@ -46,7 +50,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     // Constants for the sinusoidal motion
     final double frequency = 0.035; // Controls the oscillation speed.
     final double amplitude = 260; // Controls the range of YAW motion.
-    final double verticalAmplitude = 10; // Controls the range of vertical motion.
+    final double verticalAmplitude = 0.15; // Controls the range of vertical motion.
 
     public DefaultGenAnimation(ArmorStand armorStand) {
         this.armorStand = ((CraftArmorStand) armorStand).getHandle();
@@ -69,7 +73,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     public void run() {
         // Calculate sinusoidal values for YAW and MotY
         float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
-        float sinusoidalMotY = (float) (Math.sin(frequency * tickCount) * verticalAmplitude);
+        float sinusoidalMotY = (float) (Math.sin((frequency * tickCount) + Math.PI/2) * verticalAmplitude);
 
         // Update the armor stand's YAW and MotY based on the sinusoidal functions
         final double lastMotY = getArmorStandMotY();
@@ -79,14 +83,16 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
         armorStand.aD = false; // SETTING ON GROUND TO FALSE
 
-        PositionMoveRotation pos = new PositionMoveRotation(null,armorStand.dv(), (float) armorStand.dv().d, (float) armorStand.dv().e);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(armorStand.du(), delta, 0, 0);
+        final Set<Relative> set = new HashSet<>();
 
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),pos, armorStand.);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),positionMoveRotation, set, false);
+
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-//            v1_21_R2.sendPackets(p, teleportPacket, moveLookPacket);
-            v1_21_R2.sendPackets(p, moveLookPacket);
+            v1_21_R2.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;
     }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -106,14 +106,14 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     }
 
     private void setArmorStandMotY(double y) {
-        armorStand.i(new Vec3D(0, y, 0));
+        armorStand.h(new Vec3D(0, y, 0));
     }
 
     private void addArmorStandMotY(double y) {
-        armorStand.i(new Vec3D(0, getArmorStandMotY() + y, 0));
+        armorStand.h(new Vec3D(0, getArmorStandMotY() + y, 0));
     }
 
     private double getArmorStandMotY() {
-        return armorStand.ah().d;
+        return armorStand.dz().e;
     }
 }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -1,0 +1,113 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2;
+
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import net.minecraft.network.protocol.game.PacketPlayOutEntity;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R2.entity.CraftArmorStand;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * @author Lagggpixel
+ * @since May 10, 2024
+ */
+public class DefaultGenAnimation implements IGeneratorAnimation {
+
+    private final Entity armorStand;
+    private final Location loc;
+    private int tickCount = 0; // A counter to keep track of the ticks since the animation started.
+
+    // Constants for the sinusoidal motion
+    final double frequency = 0.035; // Controls the oscillation speed.
+    final double amplitude = 260; // Controls the range of YAW motion.
+    final double verticalAmplitude = 10; // Controls the range of vertical motion.
+
+    public DefaultGenAnimation(ArmorStand armorStand) {
+        this.armorStand = ((CraftArmorStand) armorStand).getHandle();
+        this.loc = armorStand.getLocation();
+        setArmorStandYAW(0);
+        setArmorStandMotY(0);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "bw2023:default";
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("BedWars2023");
+    }
+
+    @Override
+    public void run() {
+        // Calculate sinusoidal values for YAW and MotY
+        float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
+        float sinusoidalMotY = (float) (Math.sin(frequency * tickCount) * verticalAmplitude);
+
+        // Update the armor stand's YAW and MotY based on the sinusoidal functions
+        final double lastMotY = getArmorStandMotY();
+        setArmorStandYAW(sinusoidalYaw);
+        addArmorStandMotY(sinusoidalMotY);
+
+        armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
+        armorStand.aG = false; // SETTING ON GROUND TO FALSE
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.an(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            v1_21_R1.sendPackets(p, teleportPacket, moveLookPacket);
+        }
+        tickCount++;
+    }
+
+    private void setArmorStandYAW(float yaw) {
+        armorStand.t(yaw);
+    }
+
+    private void addArmorStandYAW(float yaw) {
+        armorStand.t(getArmorStandYAW() + yaw);
+    }
+
+    private float getArmorStandYAW() {
+        return armorStand.dE();
+    }
+
+    private void setArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, y, 0));
+    }
+
+    private void addArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, getArmorStandMotY() + y, 0));
+    }
+
+    private double getArmorStandMotY() {
+        return armorStand.ag().d;
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -24,6 +24,7 @@ import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
 import net.minecraft.network.protocol.game.PacketPlayOutEntity;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -76,27 +77,30 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         addArmorStandMotY(sinusoidalMotY);
 
         armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
-        armorStand.aG = false; // SETTING ON GROUND TO FALSE
+        armorStand.aD = false; // SETTING ON GROUND TO FALSE
 
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
-        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.an(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+        PositionMoveRotation pos = new PositionMoveRotation(null,armorStand.dv(), (float) armorStand.dv().d, (float) armorStand.dv().e);
+
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),pos, armorStand.);
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            v1_21_R1.sendPackets(p, teleportPacket, moveLookPacket);
+//            v1_21_R2.sendPackets(p, teleportPacket, moveLookPacket);
+            v1_21_R2.sendPackets(p, moveLookPacket);
         }
         tickCount++;
     }
 
     private void setArmorStandYAW(float yaw) {
-        armorStand.t(yaw);
+        armorStand.v(yaw);
     }
 
     private void addArmorStandYAW(float yaw) {
-        armorStand.t(getArmorStandYAW() + yaw);
+        armorStand.v(getArmorStandYAW() + yaw);
     }
 
     private float getArmorStandYAW() {
-        return armorStand.dE();
+        return armorStand.dM();
     }
 
     private void setArmorStandMotY(double y) {
@@ -108,6 +112,6 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     }
 
     private double getArmorStandMotY() {
-        return armorStand.ag().d;
+        return armorStand.ah().d;
     }
 }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -37,10 +37,6 @@ import org.bukkit.plugin.Plugin;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author Lagggpixel
- * @since May 10, 2024
- */
 public class DefaultGenAnimation implements IGeneratorAnimation {
 
     private final Entity armorStand;
@@ -87,7 +83,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         final var positionMoveRotation = new PositionMoveRotation(armorStand.du(), delta, 0, 0);
         final Set<Relative> set = new HashSet<>();
 
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),positionMoveRotation, set, false);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(), positionMoveRotation, set, false);
 
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -37,10 +37,6 @@ import org.bukkit.plugin.Plugin;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author Lagggpixel
- * @since May 10, 2024
- */
 public class DefaultGenAnimation implements IGeneratorAnimation {
 
     private final Entity armorStand;

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
+
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableFactory.java
@@ -1,0 +1,47 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DespawnableFactory {
+
+    private final VersionSupport versionSupport;
+    private final List<DespawnableProvider<? extends LivingEntity>> providers = new ArrayList<>();
+
+    public DespawnableFactory(VersionSupport versionSupport) {
+        this.versionSupport = versionSupport;
+        providers.add(new TeamIronGolem());
+        providers.add(new TeamSilverfish());
+    }
+
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+        return providers.stream().filter(provider -> provider.getType() == attr.type())
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
@@ -1,0 +1,92 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.EntityInsentient;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.ai.attributes.GenericAttributes;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalSelector;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalNearestAttackableTarget;
+import net.minecraft.world.entity.player.EntityHuman;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R2.entity.CraftEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public abstract class DespawnableProvider<T> {
+
+    abstract DespawnableType getType();
+
+    abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
+
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+
+    protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
+        var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
+        return null == despawnable || despawnable.getTeam() != team;
+    }
+
+    protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bX;
+    }
+
+    protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bW;
+    }
+
+    protected void clearSelectors(@NotNull EntityCreature entityLiving) {
+        entityLiving.bW.b().clear();
+        entityLiving.bX.b().clear();
+    }
+
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+                entityLiving -> {
+                    if (entityLiving instanceof EntityHuman) {
+                        return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
+                                !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
+                                !team.getArena().isReSpawning(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId())
+                                && !team.getArena().isSpectator(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId());
+                    }
+                    return notSameTeam(entityLiving, team, api);
+                });
+    }
+
+    protected void applyDefaultSettings(org.bukkit.entity.@NotNull LivingEntity bukkitEntity, DespawnableAttributes attr,
+                                        ITeam team) {
+        bukkitEntity.setRemoveWhenFarAway(false);
+        bukkitEntity.setPersistent(true);
+        bukkitEntity.setCustomNameVisible(true);
+        bukkitEntity.setCustomName(getDisplayName(attr, team));
+
+        var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
+
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.s)).a(attr.health());
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.v)).a(attr.speed());
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.c)).a(attr.damage());
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
@@ -51,21 +51,21 @@ public abstract class DespawnableProvider<T> {
     }
 
     protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
-        return entityLiving.bX;
+        return entityLiving.bU;
     }
 
     protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
-        return entityLiving.bW;
+        return entityLiving.bT;
     }
 
     protected void clearSelectors(@NotNull EntityCreature entityLiving) {
-        entityLiving.bW.b().clear();
-        entityLiving.bX.b().clear();
+        entityLiving.bT.b().clear();
+        entityLiving.bU.b().clear();
     }
 
     protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
         return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
-                entityLiving -> {
+                (entityLiving, sourceEntity) -> { // Two parameters now
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
                                 !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
@@ -85,8 +85,8 @@ public abstract class DespawnableProvider<T> {
 
         var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
 
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.s)).a(attr.health());
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.v)).a(attr.speed());
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.c)).a(attr.damage());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.s)).a(attr.health());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.v)).a(attr.speed());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.c)).a(attr.damage());
     }
 }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableType.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableType.java
@@ -1,0 +1,26 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+public enum DespawnableType {
+    IRON_GOLEM,
+    SILVERFISH
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamIronGolem.java
@@ -1,0 +1,78 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.animal.EntityIronGolem;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R2.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamIronGolem extends DespawnableProvider<IronGolem> {
+
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.IRON_GOLEM;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+
+        var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntityIronGolem) ((CraftEntity) bukkitEntity).getHandle();
+
+        clearSelectors(entity);
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.5D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamSilverfish.java
@@ -1,0 +1,76 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.monster.EntitySilverfish;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R2.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamSilverfish extends DespawnableProvider<Silverfish> {
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.SILVERFISH;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    @Override
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+        var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntitySilverfish) ((CraftEntity) bukkitEntity).getHandle();
+        clearSelectors(entity);
+
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.9D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
@@ -51,10 +51,10 @@ public class HoloLine implements IHoloLine {
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
         PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket);
     }
 
     @Override
@@ -94,10 +94,10 @@ public class HoloLine implements IHoloLine {
         entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
         if (isDestroyed()) return;
 
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class HoloLine implements IHoloLine {
 
     @Override
     public void remove() {
-        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
         v1_21_R2.sendPacket(hologram.getPlayer(), packet);
     }
 

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
@@ -1,0 +1,150 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.v1_21_R2;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R2.util.CraftChatMessage;
+
+public class HoloLine implements IHoloLine {
+    private String text;
+    private IHologram hologram;
+    public final EntityArmorStand entity;
+    private boolean showing = true;
+    private boolean destroyed = false;
+
+    public HoloLine(String text, IHologram hologram) {
+        this.text = text;
+        this.hologram = hologram;
+        entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        entity.p(true);
+        entity.k(true);
+        entity.ag = true;
+        Location loc = hologram.getLocation();
+        entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
+
+        PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void setText(String text) {
+        this.text = text;
+        update();
+    }
+
+    @Override
+    public void setText(String text, boolean update) {
+        this.text = text;
+
+        if (update) {
+            update();
+        }
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setHologram(IHologram hologram) {
+        this.hologram = hologram;
+    }
+
+    @Override
+    public IHologram getHologram() {
+        return hologram;
+    }
+
+    @Override
+    public void update() {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        entity.n(true);
+        update();
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        entity.n(false);
+        update();
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public void reveal() {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R2.sendPacket(hologram.getPlayer(), packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update();
+    }
+
+    @Override
+    public void remove() {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
+        v1_21_R2.sendPacket(hologram.getPlayer(), packet);
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+        remove();
+        hologram.removeLine(this);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
@@ -27,10 +27,16 @@ import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
 import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
 import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R2.util.CraftChatMessage;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -52,9 +58,13 @@ public class HoloLine implements IHoloLine {
 
         PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -95,9 +105,13 @@ public class HoloLine implements IHoloLine {
         if (isDestroyed()) return;
 
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
     }
 
     @Override

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
@@ -1,0 +1,285 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Hologram implements IHologram {
+    private final Player p;
+    private List<IHoloLine> lines;
+    private final Location loc;
+    private double gap = 0.25;
+    private boolean showing = true;
+
+    public Hologram(Player p, List<IHoloLine> lines, Location loc) {
+        this.p = p;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    public Player getPlayer() {
+        return this.p;
+    }
+
+    public Hologram(Player p, Location loc, List<String> lines) {
+        this.p = p;
+        this.loc = loc;
+        this.lines = new ArrayList<>();
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line) {
+        this.lines.add(line);
+    }
+
+    @Override
+    public void removeLine(IHoloLine line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public void removeLine(int index) {
+        this.lines.remove(index);
+    }
+
+    @Override
+    public void clearLines() {
+        this.lines.clear();
+    }
+
+    @Override
+    public void update() {
+        for (IHoloLine line : this.lines) {
+            line.update();
+        }
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        for (IHoloLine line : this.lines) {
+            line.show();
+        }
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        for (IHoloLine line : this.lines) {
+            line.hide();
+        }
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public int size() {
+        return this.lines.size();
+    }
+
+    @Override
+    public IHoloLine getLine(int index) {
+        return this.lines.get(index);
+    }
+
+    @Override
+    public List<IHoloLine> getLines() {
+        return this.lines;
+    }
+
+    @Override
+    public Location getLocation() {
+        return this.loc;
+    }
+
+    @Override
+    public void setLines(String[] lines, boolean update) {
+        this.lines.clear();
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLines(List<IHoloLine> lines, boolean update) {
+        this.lines = lines;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line) {
+        this.lines.set(index, line);
+        this.lines.get(index).update();
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line, boolean update) {
+        this.lines.set(index, line);
+        if (update) {
+            this.lines.get(index).update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, String line) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line);
+    }
+
+    @Override
+    public void setLine(int index, String line, boolean update) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line, update);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line) {
+        this.lines.remove(index);
+        this.lines.add(index, line);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line, boolean update) {
+        this.lines.add(index, line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void insertLine(int index, String line) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+    }
+
+    @Override
+    public void insertLine(int index, String line, boolean update) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line, boolean update) {
+        this.lines.add(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(String line) {
+        this.lines.add(new HoloLine(line, this));
+    }
+
+    @Override
+    public void addLine(String line, boolean update) {
+        this.lines.add(new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(IHoloLine line, boolean update) {
+        this.lines.remove(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(int index, boolean update) {
+        this.lines.remove(index);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void clearLines(boolean update) {
+        this.lines.clear();
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setGap(double gap) {
+        this.gap = gap;
+        this.update();
+    }
+
+    @Override
+    public void setGap(double gap, boolean update) {
+        this.gap = gap;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public double getGap() {
+        return this.gap;
+    }
+
+    @Override
+    public void remove() {
+        for (IHoloLine line : this.lines) line.remove();
+        lines.clear();
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -420,6 +420,8 @@ public final class v1_21_R2 extends VersionSupport {
 
     @Override
     public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        if (i == null) return false;
+        if (i.getType() == org.bukkit.Material.AIR) return false;
         RtagItem rtagItem = new RtagItem(i);
         OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
         return tag.isNotEmpty();
@@ -883,7 +885,7 @@ public final class v1_21_R2 extends VersionSupport {
                 nmsEntity.hashCode(),
                 nmsEntity.cG(),
                 nmsEntity.dB(),
-                nmsEntity.dB(),
+                nmsEntity.dD(),
                 nmsEntity.dH(),
                 nmsEntity.dO(),
                 nmsEntity.getBukkitYaw(),

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -1,0 +1,897 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R2;
+
+import com.mojang.datafixers.util.Pair;
+import com.saicone.rtag.RtagItem;
+import com.saicone.rtag.util.OptionalType;
+import com.saicone.rtag.util.SkullTexture;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.arena.team.TeamColor;
+import com.tomkeuper.bedwars.api.entity.Despawnable;
+import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
+import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import com.tomkeuper.bedwars.support.version.common.VersionCommon;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable.DespawnableAttributes;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable.DespawnableFactory;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.despawnable.DespawnableType;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.hologram.HoloLine;
+import com.tomkeuper.bedwars.support.version.v1_21_R2.hologram.Hologram;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.core.particles.ParticleParamRedstone;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.entity.item.EntityTNTPrimed;
+import net.minecraft.world.entity.projectile.IProjectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBase;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Ladder;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.v1_21_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R2.entity.*;
+import org.bukkit.craftbukkit.v1_21_R2.inventory.CraftItemStack;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.*;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+
+import static com.tomkeuper.bedwars.api.language.Language.getList;
+
+public final class v1_21_R2 extends VersionSupport {
+
+    private final DespawnableFactory despawnableFactory;
+
+    public v1_21_R2(Plugin plugin, String name) {
+        super(plugin, name);
+        loadDefaultEffects();
+        this.despawnableFactory = new DespawnableFactory(this);
+    }
+
+    @Override
+    public void registerCommand(String name, Command cmd) {
+        ((CraftServer) getPlugin().getServer()).getCommandMap().register(name, cmd);
+    }
+
+    @Override
+    public void sendTitle(Player p, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
+    }
+
+    @Override
+    public void playAction(Player p, String text) {
+        p.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.translateAlternateColorCodes('&', text)
+                )
+        );
+    }
+
+    @Override
+    public boolean isBukkitCommandRegistered(String name) {
+        return ((CraftServer) getPlugin().getServer()).getCommandMap().getCommand(name) != null;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemInHand(@NotNull Player p) {
+        return p.getInventory().getItemInMainHand();
+    }
+
+    @Override
+    public void hideEntity(Entity e, Player p) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(e.getEntityId());
+        sendPacket(p, packet);
+    }
+
+    @Override
+    public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemArmor || i instanceof ItemElytra;
+    }
+
+    @Override
+    public boolean isTool(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemTool;
+    }
+
+    @Override
+    public boolean isSword(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemSword;
+    }
+
+    @Override
+    public boolean isAxe(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemAxe;
+    }
+
+    @Override
+    public boolean isBow(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemBow;
+    }
+
+
+    @Override
+    public boolean isProjectile(org.bukkit.inventory.ItemStack itemStack) {
+        var entity = getEntity(itemStack);
+        if (null == entity) return false;
+        return entity instanceof IProjectile;
+    }
+
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.@NotNull ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
+    public void registerEntities() {
+
+    }
+
+    @Override
+    public void spawnShop(Location loc, String name1, List<Player> players, IArena arena) {
+        Location l = loc.clone();
+
+        if (l.getWorld() == null) return;
+        Villager vlg = (Villager) l.getWorld().spawnEntity(loc, EntityType.VILLAGER);
+        vlg.setAI(false);
+        vlg.setRemoveWhenFarAway(false);
+        vlg.setCollidable(false);
+        vlg.setInvulnerable(true);
+        vlg.setSilent(true);
+    }
+
+    @Override
+    public void spawnShopHologram(Location loc, String name1, List<Player> players, IArena arena, ITeam team) {
+        for (Player p : players) {
+            String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
+            IHologram h = createHologram(p, loc, nume);
+
+            new ShopHolo(h, loc, arena, team);
+        }
+
+        for (Player p : players) {
+            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+        }
+    }
+
+    @Override
+    public double getDamage(org.bukkit.inventory.ItemStack i) {
+        var tag = getTag(i);
+        if (null == tag) {
+            throw new RuntimeException("Provided item has no Tag");
+        }
+        return tag.k("generic.attackDamage");
+    }
+
+    @Override
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+        var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH
+        );
+    }
+
+    @Override
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+        var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM
+        );
+    }
+
+    @Override
+    public void minusAmount(Player p, org.bukkit.inventory.@NotNull ItemStack i, int amount) {
+        if (i.getAmount() - amount <= 0) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
+            return;
+        }
+        i.setAmount(i.getAmount() - amount);
+        //noinspection UnstableApiUsage
+        p.updateInventory();
+    }
+
+    @Override
+    public void setSource(TNTPrimed tnt, Player owner) {
+        EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
+        EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
+        try {
+            Field sourceField = EntityTNTPrimed.class.getDeclaredField("h");
+            sourceField.setAccessible(true);
+            sourceField.set(nmsTNT, nmsEntityLiving);
+        } catch (Exception ex) {
+            //noinspection CallToPrintStackTrace
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void voidKill(Player p) {
+        @SuppressWarnings("UnstableApiUsage")
+        EntityDamageEvent event = new EntityDamageEvent(p, EntityDamageEvent.DamageCause.VOID, DamageSource.builder(DamageType.GENERIC).build(), 1000.0);
+        //noinspection removal
+        p.setLastDamageCause(event);
+        p.setHealth(0);
+    }
+
+    @Override
+    public void hideArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public void showArmor(Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(victim.getInventory().getHelmet())));
+        items.add(new Pair<>(EnumItemSlot.e, CraftItemStack.asNMSCopy(victim.getInventory().getChestplate())));
+        items.add(new Pair<>(EnumItemSlot.d, CraftItemStack.asNMSCopy(victim.getInventory().getLeggings())));
+        items.add(new Pair<>(EnumItemSlot.c, CraftItemStack.asNMSCopy(victim.getInventory().getBoots())));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public EnderDragon spawnDragon(Location l, ITeam team) {
+        if (l == null || l.getWorld() == null) {
+            getPlugin().getLogger().log(Level.WARNING, "Could not spawn Dragon. Location is null");
+            return null;
+        }
+        EnderDragon ed = (EnderDragon) l.getWorld().spawnEntity(l, EntityType.ENDER_DRAGON);
+        ed.setPhase(EnderDragon.Phase.CIRCLING);
+        return ed;
+    }
+
+    @Override
+    public void colorBed(ITeam bwt) {
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
+                if (bed instanceof Bed) {
+                    bed.setType(bwt.getColor().bedMaterial());
+                    bed.update();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
+        try {
+            // blast resistance
+            Field field = BlockBase.class.getDeclaredField("aH");
+            field.setAccessible(true);
+            // end stone
+            field.set(Blocks.fz, endStoneBlast);
+            // obsidian
+            field.set(Blocks.co, glassBlast);
+            // standard glass
+            field.set(Blocks.aQ, glassBlast);
+
+            var coloredGlass = new net.minecraft.world.level.block.Block[]{
+                    Blocks.ei, Blocks.ej, Blocks.ek, Blocks.el,
+                    Blocks.em, Blocks.en, Blocks.eo, Blocks.ep,
+                    Blocks.eq, Blocks.er, Blocks.es, Blocks.et,
+                    Blocks.eu, Blocks.ev, Blocks.ew, Blocks.ex,
+
+                    Blocks.aQ,
+            };
+
+            Arrays.stream(coloredGlass).forEach(
+                    glass -> {
+                        try {
+                            field.set(glass, glassBlast);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            //noinspection CallToPrintStackTrace
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void setBlockTeamColor(Block block, TeamColor teamColor) {
+        if (block.getType().toString().contains("STAINED_GLASS") || block.getType().toString().equals("GLASS")) {
+            block.setType(teamColor.glassMaterial());
+        } else if (block.getType().toString().contains("_TERRACOTTA")) {
+            block.setType(teamColor.glazedTerracottaMaterial());
+        } else if (block.getType().toString().contains("_WOOL")) {
+            block.setType(teamColor.woolMaterial());
+        }
+    }
+
+    @Override
+    public void setCollide(Player p, IArena a, boolean value) {
+        p.setCollidable(value);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addCustomData(org.bukkit.inventory.ItemStack i, String data) {
+        return RtagItem.edit(i, tag -> {
+            tag.set(data, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        });
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {
+        return RtagItem.edit(itemStack, tag -> {
+            tag.set(value, key);
+        });
+    }
+
+    @Override
+    public String getTag(org.bukkit.inventory.ItemStack itemStack, String key) {
+        var tag = getTag(itemStack);
+        return tag == null ? null : tag.e(key) ? tag.l(key) : null;
+    }
+
+    @Override
+    public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return tag.isNotEmpty();
+    }
+
+    @Override
+    public String getCustomData(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return (tag.isEmpty() || tag.isNotInstance(String.class)) ? null : tag.asString(null);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack colourItem(org.bukkit.inventory.ItemStack itemStack, ITeam bedWarsTeam) {
+        if (itemStack == null) return null;
+        String type = itemStack.getType().toString();
+        if (isBed(itemStack.getType())) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().bedMaterial(), itemStack.getAmount());
+        } else if (type.contains("_STAINED_GLASS_PANE")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassPaneMaterial(), itemStack.getAmount());
+        } else if (type.contains("STAINED_GLASS") || type.equals("GLASS")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassMaterial(), itemStack.getAmount());
+        } else if (type.contains("_TERRACOTTA")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glazedTerracottaMaterial(), itemStack.getAmount());
+        } else if (type.contains("_WOOL")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().woolMaterial(), itemStack.getAmount());
+        }
+        return itemStack;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack createItemStack(String material, int amount, short data) {
+        org.bukkit.inventory.ItemStack i;
+        try {
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.valueOf(material), amount);
+        } catch (Exception ex) {
+            getPlugin().getLogger().log(Level.WARNING, material + " is not a valid " + getName() + " material!");
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.BEDROCK);
+        }
+        return i;
+    }
+
+    @Override
+    public Material materialFireball() {
+        return org.bukkit.Material.FIRE_CHARGE;
+    }
+
+    @Override
+    public org.bukkit.Material materialPlayerHead() {
+        return org.bukkit.Material.PLAYER_HEAD;
+    }
+
+    @Override
+    public org.bukkit.Material materialSnowball() {
+        return org.bukkit.Material.SNOWBALL;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenHelmet() {
+        return org.bukkit.Material.GOLDEN_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenChestPlate() {
+        return org.bukkit.Material.GOLDEN_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenLeggings() {
+        return org.bukkit.Material.GOLDEN_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteHelmet() {
+        return Material.NETHERITE_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteChestPlate() {
+        return Material.NETHERITE_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteLeggings() {
+        return Material.NETHERITE_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialElytra() {
+        return Material.ELYTRA;
+    }
+
+    @Override
+    public org.bukkit.Material materialCake() {
+        return org.bukkit.Material.CAKE;
+    }
+
+    @Override
+    public org.bukkit.Material materialCraftingTable() {
+        return org.bukkit.Material.CRAFTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEnchantingTable() {
+        return org.bukkit.Material.ENCHANTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEndStone() {
+        return Material.END_STONE;
+    }
+
+    @Override
+    public org.bukkit.Material woolMaterial() {
+        return org.bukkit.Material.WHITE_WOOL;
+    }
+
+    @Override
+    public void setJoinSignBackground(BlockState b, Material material) {
+        if (b.getBlockData() instanceof WallSign) {
+            b.getBlock().getRelative(((WallSign) b.getBlockData()).getFacing().getOppositeFace()).setType(material);
+        }
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack redGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.RED_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack greenGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.LIME_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public String getShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem item = new RtagItem(itemStack);
+        OptionalType tag = item.getOptional(VersionSupport.PLUGIN_TAG_TIER_KEY);
+        return tag.isEmpty() ? "null" : tag.asString("null");
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack, String identifier) {
+        RtagItem item = new RtagItem(itemStack);
+        item.set(identifier, VersionSupport.PLUGIN_TAG_TIER_KEY);
+        item.load();
+        return item.getItem();
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getPlayerHead(Player player, org.bukkit.inventory.ItemStack copyTagFrom) {
+        org.bukkit.inventory.ItemStack head = SkullTexture.getTexturedHead(player.getUniqueId().toString());
+
+        if (copyTagFrom != null) {
+            var tag = getTag(copyTagFrom);
+            RtagItem rtagItem = new RtagItem(head);
+            rtagItem.set(tag, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+            rtagItem.load();
+            head = rtagItem.getItem();
+        }
+
+        return head;
+    }
+
+    @Override
+    public void sendPlayerSpawnPackets(Player respawned, IArena arena) {
+        if (respawned == null) return;
+        if (arena == null) return;
+        if (!arena.isPlayer(respawned)) return;
+
+        // if method was used when the player was still in re-spawning screen
+        if (arena.getRespawnSessions().containsKey(respawned)) return;
+
+        EntityPlayer entityPlayer = getPlayer(respawned);
+        PacketPlayOutSpawnEntity show = newPacketPlayOutSpawnEntity(entityPlayer);
+        PacketPlayOutEntityVelocity playerVelocity = new PacketPlayOutEntityVelocity(entityPlayer);
+        // we send head rotation packet because sometimes on respawn others see him with bad rotation
+        PacketPlayOutEntityHeadRotation head = new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()));
+
+        // retrieve current armor and in-hand items
+        // we send a packet later for timing issues where other players do not see them
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = getPlayerEquipment(entityPlayer);
+
+
+        for (Player p : arena.getPlayers()) {
+            if (p == null) continue;
+            if (p.equals(respawned)) continue;
+            // if p is in re-spawning screen continue
+            if (arena.getRespawnSessions().containsKey(p)) continue;
+
+            EntityPlayer boundTo = getPlayer(p);
+            if (p.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(p.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to regular players
+                    sendPackets(
+                            p, show, head, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list)
+                    );
+
+                    // send nearby players to respawned player
+                    // if the player has invisibility hide armor
+                    if (p.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                        hideArmor(p, respawned);
+                    } else {
+                        PacketPlayOutSpawnEntity show2 = newPacketPlayOutSpawnEntity(boundTo);
+
+                        PacketPlayOutEntityVelocity playerVelocity2 = new PacketPlayOutEntityVelocity(boundTo);
+                        PacketPlayOutEntityHeadRotation head2 = new PacketPlayOutEntityHeadRotation(boundTo, getCompressedAngle(boundTo.getBukkitYaw()));
+                        sendPackets(respawned, show2, playerVelocity2, head2);
+                        showArmor(p, respawned);
+                    }
+                }
+            }
+        }
+
+        for (Player spectator : arena.getSpectators()) {
+            if (spectator == null) continue;
+            if (spectator.equals(respawned)) continue;
+            respawned.hidePlayer(getPlugin(), spectator);
+            if (spectator.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(spectator.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to spectator
+                    sendPackets(
+                            spectator, show, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list),
+                            new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()))
+                    );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getInventoryName(@NotNull InventoryEvent e) {
+        return e.getView().getTitle();
+    }
+
+    @Override
+    public void setUnbreakable(ItemMeta itemMeta) {
+        itemMeta.setUnbreakable(true);
+    }
+
+    @Override
+    public int getVersion() {
+        return 12;
+    }
+
+    @Override
+    public void registerVersionListeners() {
+        new VersionCommon(this);
+    }
+
+    @Override
+    public String getMainLevel() {
+        //noinspection deprecation
+        return ((DedicatedServer) MinecraftServer.getServer()).a().n;
+    }
+
+    @Override
+    public Fireball setFireballDirection(Fireball fireball, Vector vector) {
+        fireball.setDirection(vector);
+        return fireball;
+    }
+
+    @Override
+    public void playRedStoneDot(Player player) {
+        Color color = Color.RED;
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                new ParticleParamRedstone(
+                        new Vector3f((float) color.getRed(),
+                                (float) color.getGreen(),
+                                (float) color.getBlue()), (float) 1
+                ),
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player inWorld : player.getWorld().getPlayers()) {
+            if (inWorld.equals(player)) continue;
+            sendPacket(inWorld, particlePacket);
+        }
+    }
+
+    @Override
+    public void clearArrowsFromPlayerBody(Player player) {
+        // minecraft clears them on death on newer version
+    }
+
+    @Override
+    public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
+        b.getRelative(x, y, z).setType(color.woolMaterial());
+        a.addPlacedBlock(b.getRelative(x, y, z));
+        return b.getRelative(x, y, z);
+    }
+
+    @Override
+    public Block placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
+        Block block = b.getRelative(x, y, z);  //ladder block
+        block.setType(Material.LADDER);
+        Ladder ladder = (Ladder) block.getBlockData();
+        a.addPlacedBlock(block);
+        switch (ladderData) {
+            case 2 -> {
+                ladder.setFacing(BlockFace.NORTH);
+                block.setBlockData(ladder);
+            }
+            case 3 -> {
+                ladder.setFacing(BlockFace.SOUTH);
+                block.setBlockData(ladder);
+            }
+            case 4 -> {
+                ladder.setFacing(BlockFace.WEST);
+                block.setBlockData(ladder);
+            }
+            case 5 -> {
+                ladder.setFacing(BlockFace.EAST);
+                block.setBlockData(ladder);
+            }
+        }
+        return b;
+    }
+
+    @Override
+    public void playVillagerEffect(Player player, Location location) {
+        player.spawnParticle(Particle.HAPPY_VILLAGER, location, 1);
+    }
+
+    @Override
+    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, location, linesList);
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, linesList, location);
+    }
+
+    @Override
+    public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
+        return new HoloLine(text, hologram);
+    }
+
+    @Override
+    public IGeneratorAnimation createDefaultGeneratorAnimation(ArmorStand armorStand) {
+        return new DefaultGenAnimation(armorStand);
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, destroy);
+        }
+    }
+
+    @Override
+    public ArmorStand createPacketArmorStand(Location loc) {
+        if (loc.getWorld() == null) {
+            throw new RuntimeException("World of a location should not be null.");
+        }
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+
+        for (Player p : loc.getWorld().getPlayers()) {
+            sendPacket(p, spawn);
+        }
+        return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);
+    }
+
+    public static void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().c.b(packet);
+    }
+
+    public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().c;
+        for (Packet<?> p : packets) {
+            connection.b(p);
+        }
+    }
+
+    /**
+     * Gets the NMS Item from ItemStack
+     */
+    private @Nullable Item getItem(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.g();
+    }
+
+    /**
+     * Gets the NMS Entity from ItemStack
+     */
+    private @Nullable net.minecraft.world.entity.Entity getEntity(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.E();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem rtagItem = new RtagItem(itemStack);
+        return (NBTTagCompound) rtagItem.getTag();
+    }
+
+    public EntityPlayer getPlayer(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    public List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> getPlayerEquipment(@NotNull EntityPlayer entityPlayer) {
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = new ArrayList<>();
+        list.add(new Pair<>(EnumItemSlot.a, entityPlayer.a(EnumItemSlot.a)));
+        list.add(new Pair<>(EnumItemSlot.b, entityPlayer.a(EnumItemSlot.b)));
+        list.add(new Pair<>(EnumItemSlot.f, entityPlayer.a(EnumItemSlot.f)));
+        list.add(new Pair<>(EnumItemSlot.e, entityPlayer.a(EnumItemSlot.e)));
+        list.add(new Pair<>(EnumItemSlot.d, entityPlayer.a(EnumItemSlot.d)));
+        list.add(new Pair<>(EnumItemSlot.c, entityPlayer.a(EnumItemSlot.c)));
+
+        return list;
+    }
+
+    public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
+        return new PacketPlayOutSpawnEntity(
+                nmsEntity.hashCode(),
+                nmsEntity.cz(),
+                nmsEntity.dt(),
+                nmsEntity.dv(),
+                nmsEntity.dz(),
+                nmsEntity.dG(),
+                nmsEntity.getBukkitYaw(),
+                nmsEntity.am(),
+                0,
+                nmsEntity.dr(),
+                nmsEntity.ct()
+        );
+    }
+}

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -144,8 +144,7 @@ public final class v1_21_R2 extends VersionSupport {
     public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
         var i = getItem(itemStack);
         if (null == i) return false;
-        // TODO check if elytra is armor
-        return i instanceof ItemArmor;
+        return i instanceof ItemArmor || itemStack.getType() == materialElytra();
     }
 
     @Override

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -280,14 +280,7 @@ public final class v1_21_R2 extends VersionSupport {
     public void setSource(TNTPrimed tnt, Player owner) {
         EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
         EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
-        try {
-            Field sourceField = EntityTNTPrimed.class.getDeclaredField("i");
-            sourceField.setAccessible(true);
-            sourceField.set(nmsTNT, nmsEntityLiving);
-        } catch (Exception ex) {
-            //noinspection CallToPrintStackTrace
-            ex.printStackTrace();
-        }
+        nmsTNT.i = nmsEntityLiving;
     }
 
     @Override

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -349,7 +349,7 @@ public final class v1_21_R2 extends VersionSupport {
     public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
         try {
             // blast resistance
-            Field field = BlockBase.class.getDeclaredField("aH");
+            Field field = BlockBase.class.getDeclaredField("aI");
             field.setAccessible(true);
             // end stone
             field.set(Blocks.fN, endStoneBlast);
@@ -815,7 +815,7 @@ public final class v1_21_R2 extends VersionSupport {
             throw new RuntimeException("World of a location should not be null.");
         }
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
-        nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
         for (Player p : loc.getWorld().getPlayers()) {

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -144,7 +144,8 @@ public final class v1_21_R2 extends VersionSupport {
     public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
         var i = getItem(itemStack);
         if (null == i) return false;
-        return i instanceof ItemArmor || i instanceof ItemElytra;
+        // TODO check if elytra is armor
+        return i instanceof ItemArmor;
     }
 
     @Override
@@ -280,7 +281,7 @@ public final class v1_21_R2 extends VersionSupport {
         EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
         EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
         try {
-            Field sourceField = EntityTNTPrimed.class.getDeclaredField("h");
+            Field sourceField = EntityTNTPrimed.class.getDeclaredField("i");
             sourceField.setAccessible(true);
             sourceField.set(nmsTNT, nmsEntityLiving);
         } catch (Exception ex) {
@@ -351,19 +352,19 @@ public final class v1_21_R2 extends VersionSupport {
             Field field = BlockBase.class.getDeclaredField("aH");
             field.setAccessible(true);
             // end stone
-            field.set(Blocks.fz, endStoneBlast);
+            field.set(Blocks.fN, endStoneBlast);
             // obsidian
-            field.set(Blocks.co, glassBlast);
+            field.set(Blocks.cv, glassBlast);
             // standard glass
-            field.set(Blocks.aQ, glassBlast);
+            field.set(Blocks.aX, glassBlast);
 
             var coloredGlass = new net.minecraft.world.level.block.Block[]{
-                    Blocks.ei, Blocks.ej, Blocks.ek, Blocks.el,
-                    Blocks.em, Blocks.en, Blocks.eo, Blocks.ep,
-                    Blocks.eq, Blocks.er, Blocks.es, Blocks.et,
-                    Blocks.eu, Blocks.ev, Blocks.ew, Blocks.ex,
+                    Blocks.ev, Blocks.ew, Blocks.ex, Blocks.ey,
+                    Blocks.ez, Blocks.eA, Blocks.eB, Blocks.eC,
+                    Blocks.eD, Blocks.eE, Blocks.eF, Blocks.eG,
+                    Blocks.eH, Blocks.eI, Blocks.eJ, Blocks.eK,
 
-                    Blocks.aQ,
+                    Blocks.aX,
             };
 
             Arrays.stream(coloredGlass).forEach(
@@ -676,7 +677,7 @@ public final class v1_21_R2 extends VersionSupport {
     @Override
     public String getMainLevel() {
         //noinspection deprecation
-        return ((DedicatedServer) MinecraftServer.getServer()).a().n;
+        return ((DedicatedServer) MinecraftServer.getServer()).a().l;
     }
 
     @Override
@@ -690,9 +691,7 @@ public final class v1_21_R2 extends VersionSupport {
         Color color = Color.RED;
         PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
                 new ParticleParamRedstone(
-                        new Vector3f((float) color.getRed(),
-                                (float) color.getGreen(),
-                                (float) color.getBlue()), (float) 1
+                        color.asRGB(), (float) 1
                 ),
                 true,
                 player.getLocation().getX(),
@@ -755,7 +754,7 @@ public final class v1_21_R2 extends VersionSupport {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
         Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
 
@@ -826,11 +825,11 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     public static void sendPacket(Player player, Packet<?> packet) {
-        ((CraftPlayer) player).getHandle().c.b(packet);
+        ((CraftPlayer) player).getHandle().f.b(packet);
     }
 
     public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
-        PlayerConnection connection = ((CraftPlayer) player).getHandle().c;
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().f;
         for (Packet<?> p : packets) {
             connection.b(p);
         }
@@ -844,7 +843,7 @@ public final class v1_21_R2 extends VersionSupport {
         if (null == i) {
             return null;
         }
-        return i.g();
+        return i.h();
     }
 
     /**
@@ -855,7 +854,7 @@ public final class v1_21_R2 extends VersionSupport {
         if (null == i) {
             return null;
         }
-        return i.E();
+        return i.I();
     }
 
     private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
@@ -882,16 +881,16 @@ public final class v1_21_R2 extends VersionSupport {
     public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
         return new PacketPlayOutSpawnEntity(
                 nmsEntity.hashCode(),
-                nmsEntity.cz(),
-                nmsEntity.dt(),
-                nmsEntity.dv(),
-                nmsEntity.dz(),
-                nmsEntity.dG(),
+                nmsEntity.cG(),
+                nmsEntity.dB(),
+                nmsEntity.dB(),
+                nmsEntity.dH(),
+                nmsEntity.dO(),
                 nmsEntity.getBukkitYaw(),
-                nmsEntity.am(),
+                nmsEntity.aq(),
                 0,
-                nmsEntity.dr(),
-                nmsEntity.ct()
+                nmsEntity.dz(),
+                nmsEntity.cA()
         );
     }
 }

--- a/versionsupport_v1_21_r3/build.gradle.kts
+++ b/versionsupport_v1_21_r3/build.gradle.kts
@@ -1,0 +1,27 @@
+dependencies {
+    compileOnly(projects.bedwarsApi)
+    implementation(projects.versionsupportCommon)
+    compileOnly("org.spigotmc:spigot:1.21.4-R0.1-SNAPSHOT") {
+        exclude("commons-lang", "commons-lang")
+    }
+    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    // Other modules
+    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+}
+
+tasks.compileJava {
+    options.release.set(21)
+}
+
+repositories {
+    // Important Repos
+    mavenCentral()
+    mavenLocal()
+    maven("https://repo.codemc.io/repository/nms/") // Spigot
+    maven("https://repo.papermc.io/repository/maven-public/") // com.mojang (dep of Spigot)
+    maven("https://jitpack.io") // Jitpack (RTag)
+}
+
+description = "versionsupport_v1_21_r3"

--- a/versionsupport_v1_21_r3/build.gradle.kts
+++ b/versionsupport_v1_21_r3/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.21.4-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.4")
+    compileOnly("com.saicone.rtag:rtag:1.5.9")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.4")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.4")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.9")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.9")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -76,27 +76,28 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         addArmorStandMotY(sinusoidalMotY);
 
         armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
-        armorStand.aG = false; // SETTING ON GROUND TO FALSE
+        armorStand.aD = false; // SETTING ON GROUND TO FALSE
 
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
-        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.an(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            v1_21_R1.sendPackets(p, teleportPacket, moveLookPacket);
+//            v1_21_R3.sendPackets(p, teleportPacket, moveLookPacket);
+            v1_21_R3.sendPackets(p, moveLookPacket);
         }
         tickCount++;
     }
 
     private void setArmorStandYAW(float yaw) {
-        armorStand.t(yaw);
+        armorStand.v(yaw);
     }
 
     private void addArmorStandYAW(float yaw) {
-        armorStand.t(getArmorStandYAW() + yaw);
+        armorStand.v(getArmorStandYAW() + yaw);
     }
 
     private float getArmorStandYAW() {
-        return armorStand.dE();
+        return armorStand.dM();
     }
 
     private void setArmorStandMotY(double y) {
@@ -108,6 +109,6 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     }
 
     private double getArmorStandMotY() {
-        return armorStand.ag().d;
+        return armorStand.ah().d;
     }
 }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -24,6 +24,8 @@ import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
 import net.minecraft.network.protocol.game.PacketPlayOutEntity;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -31,6 +33,9 @@ import org.bukkit.craftbukkit.v1_21_R3.entity.CraftArmorStand;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Lagggpixel
@@ -45,7 +50,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     // Constants for the sinusoidal motion
     final double frequency = 0.035; // Controls the oscillation speed.
     final double amplitude = 260; // Controls the range of YAW motion.
-    final double verticalAmplitude = 10; // Controls the range of vertical motion.
+    final double verticalAmplitude = 0.15; // Controls the range of vertical motion.
 
     public DefaultGenAnimation(ArmorStand armorStand) {
         this.armorStand = ((CraftArmorStand) armorStand).getHandle();
@@ -68,7 +73,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     public void run() {
         // Calculate sinusoidal values for YAW and MotY
         float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
-        float sinusoidalMotY = (float) (Math.sin(frequency * tickCount) * verticalAmplitude);
+        float sinusoidalMotY = (float) (Math.sin((frequency * tickCount) + Math.PI/2) * verticalAmplitude);
 
         // Update the armor stand's YAW and MotY based on the sinusoidal functions
         final double lastMotY = getArmorStandMotY();
@@ -78,12 +83,16 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
         armorStand.aD = false; // SETTING ON GROUND TO FALSE
 
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(armorStand.du(), delta, 0, 0);
+        final Set<Relative> set = new HashSet<>();
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),positionMoveRotation, set, false);
+
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-//            v1_21_R3.sendPackets(p, teleportPacket, moveLookPacket);
-            v1_21_R3.sendPackets(p, moveLookPacket);
+            v1_21_R3.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;
     }
@@ -97,7 +106,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     }
 
     private float getArmorStandYAW() {
-        return armorStand.dM();
+        return armorStand.dL();
     }
 
     private void setArmorStandMotY(double y) {
@@ -109,6 +118,6 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
     }
 
     private double getArmorStandMotY() {
-        return armorStand.ah().d;
+        return armorStand.ah().e;
     }
 }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -37,10 +37,6 @@ import org.bukkit.plugin.Plugin;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author Lagggpixel
- * @since May 10, 2024
- */
 public class DefaultGenAnimation implements IGeneratorAnimation {
 
     private final Entity armorStand;
@@ -87,7 +83,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         final var positionMoveRotation = new PositionMoveRotation(armorStand.du(), delta, 0, 0);
         final Set<Relative> set = new HashSet<>();
 
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(),positionMoveRotation, set, false);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(), positionMoveRotation, set, false);
 
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -37,10 +37,6 @@ import org.bukkit.plugin.Plugin;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * @author Lagggpixel
- * @since May 10, 2024
- */
 public class DefaultGenAnimation implements IGeneratorAnimation {
 
     private final Entity armorStand;

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -1,0 +1,113 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3;
+
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import net.minecraft.network.protocol.game.PacketPlayOutEntity;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R3.entity.CraftArmorStand;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * @author Lagggpixel
+ * @since May 10, 2024
+ */
+public class DefaultGenAnimation implements IGeneratorAnimation {
+
+    private final Entity armorStand;
+    private final Location loc;
+    private int tickCount = 0; // A counter to keep track of the ticks since the animation started.
+
+    // Constants for the sinusoidal motion
+    final double frequency = 0.035; // Controls the oscillation speed.
+    final double amplitude = 260; // Controls the range of YAW motion.
+    final double verticalAmplitude = 10; // Controls the range of vertical motion.
+
+    public DefaultGenAnimation(ArmorStand armorStand) {
+        this.armorStand = ((CraftArmorStand) armorStand).getHandle();
+        this.loc = armorStand.getLocation();
+        setArmorStandYAW(0);
+        setArmorStandMotY(0);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "bw2023:default";
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("BedWars2023");
+    }
+
+    @Override
+    public void run() {
+        // Calculate sinusoidal values for YAW and MotY
+        float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
+        float sinusoidalMotY = (float) (Math.sin(frequency * tickCount) * verticalAmplitude);
+
+        // Update the armor stand's YAW and MotY based on the sinusoidal functions
+        final double lastMotY = getArmorStandMotY();
+        setArmorStandYAW(sinusoidalYaw);
+        addArmorStandMotY(sinusoidalMotY);
+
+        armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
+        armorStand.aG = false; // SETTING ON GROUND TO FALSE
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.an(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            v1_21_R1.sendPackets(p, teleportPacket, moveLookPacket);
+        }
+        tickCount++;
+    }
+
+    private void setArmorStandYAW(float yaw) {
+        armorStand.t(yaw);
+    }
+
+    private void addArmorStandYAW(float yaw) {
+        armorStand.t(getArmorStandYAW() + yaw);
+    }
+
+    private float getArmorStandYAW() {
+        return armorStand.dE();
+    }
+
+    private void setArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, y, 0));
+    }
+
+    private void addArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, getArmorStandMotY() + y, 0));
+    }
+
+    private double getArmorStandMotY() {
+        return armorStand.ag().d;
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
+
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableFactory.java
@@ -1,0 +1,47 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DespawnableFactory {
+
+    private final VersionSupport versionSupport;
+    private final List<DespawnableProvider<? extends LivingEntity>> providers = new ArrayList<>();
+
+    public DespawnableFactory(VersionSupport versionSupport) {
+        this.versionSupport = versionSupport;
+        providers.add(new TeamIronGolem());
+        providers.add(new TeamSilverfish());
+    }
+
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+        return providers.stream().filter(provider -> provider.getType() == attr.type())
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
@@ -1,0 +1,92 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.EntityInsentient;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.ai.attributes.GenericAttributes;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalSelector;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalNearestAttackableTarget;
+import net.minecraft.world.entity.player.EntityHuman;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R3.entity.CraftEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public abstract class DespawnableProvider<T> {
+
+    abstract DespawnableType getType();
+
+    abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
+
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+
+    protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
+        var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
+        return null == despawnable || despawnable.getTeam() != team;
+    }
+
+    protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bX;
+    }
+
+    protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bW;
+    }
+
+    protected void clearSelectors(@NotNull EntityCreature entityLiving) {
+        entityLiving.bW.b().clear();
+        entityLiving.bX.b().clear();
+    }
+
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+                entityLiving -> {
+                    if (entityLiving instanceof EntityHuman) {
+                        return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
+                                !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
+                                !team.getArena().isReSpawning(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId())
+                                && !team.getArena().isSpectator(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId());
+                    }
+                    return notSameTeam(entityLiving, team, api);
+                });
+    }
+
+    protected void applyDefaultSettings(org.bukkit.entity.@NotNull LivingEntity bukkitEntity, DespawnableAttributes attr,
+                                        ITeam team) {
+        bukkitEntity.setRemoveWhenFarAway(false);
+        bukkitEntity.setPersistent(true);
+        bukkitEntity.setCustomNameVisible(true);
+        bukkitEntity.setCustomName(getDisplayName(attr, team));
+
+        var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
+
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.s)).a(attr.health());
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.v)).a(attr.speed());
+        Objects.requireNonNull(entity.eS().a(GenericAttributes.c)).a(attr.damage());
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
@@ -51,21 +51,21 @@ public abstract class DespawnableProvider<T> {
     }
 
     protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
-        return entityLiving.bX;
+        return entityLiving.bT;
     }
 
     protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
-        return entityLiving.bW;
+        return entityLiving.bS;
     }
 
     protected void clearSelectors(@NotNull EntityCreature entityLiving) {
-        entityLiving.bW.b().clear();
-        entityLiving.bX.b().clear();
+        entityLiving.bS.b().clear();
+        entityLiving.bT.b().clear();
     }
 
     protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
         return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
-                entityLiving -> {
+                (entityLiving, sourceEntity) -> { // Two parameters now
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
                                 !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
@@ -85,8 +85,8 @@ public abstract class DespawnableProvider<T> {
 
         var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
 
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.s)).a(attr.health());
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.v)).a(attr.speed());
-        Objects.requireNonNull(entity.eS().a(GenericAttributes.c)).a(attr.damage());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.s)).a(attr.health());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.v)).a(attr.speed());
+        Objects.requireNonNull(entity.eY().a(GenericAttributes.c)).a(attr.damage());
     }
 }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableType.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableType.java
@@ -1,0 +1,26 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+public enum DespawnableType {
+    IRON_GOLEM,
+    SILVERFISH
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamIronGolem.java
@@ -1,0 +1,78 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.animal.EntityIronGolem;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R3.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamIronGolem extends DespawnableProvider<IronGolem> {
+
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.IRON_GOLEM;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+
+        var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntityIronGolem) ((CraftEntity) bukkitEntity).getHandle();
+
+        clearSelectors(entity);
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.5D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamSilverfish.java
@@ -1,0 +1,76 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.monster.EntitySilverfish;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R3.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamSilverfish extends DespawnableProvider<Silverfish> {
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.SILVERFISH;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    @Override
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+        var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntitySilverfish) ((CraftEntity) bukkitEntity).getHandle();
+        clearSelectors(entity);
+
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.9D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
@@ -27,10 +27,16 @@ import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
 import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
 import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R3.util.CraftChatMessage;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -52,9 +58,13 @@ public class HoloLine implements IHoloLine {
 
         PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -95,9 +105,13 @@ public class HoloLine implements IHoloLine {
         if (isDestroyed()) return;
 
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
-//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket);
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
     }
 
     @Override

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
@@ -51,10 +51,10 @@ public class HoloLine implements IHoloLine {
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
         PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket);
     }
 
     @Override
@@ -94,10 +94,10 @@ public class HoloLine implements IHoloLine {
         entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
         if (isDestroyed()) return;
 
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+//        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class HoloLine implements IHoloLine {
 
     @Override
     public void remove() {
-        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
         v1_21_R3.sendPacket(hologram.getPlayer(), packet);
     }
 

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
@@ -1,0 +1,150 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.v1_21_R3;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R3.util.CraftChatMessage;
+
+public class HoloLine implements IHoloLine {
+    private String text;
+    private IHologram hologram;
+    public final EntityArmorStand entity;
+    private boolean showing = true;
+    private boolean destroyed = false;
+
+    public HoloLine(String text, IHologram hologram) {
+        this.text = text;
+        this.hologram = hologram;
+        entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        entity.p(true);
+        entity.k(true);
+        entity.ag = true;
+        Location loc = hologram.getLocation();
+        entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
+
+        PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void setText(String text) {
+        this.text = text;
+        update();
+    }
+
+    @Override
+    public void setText(String text, boolean update) {
+        this.text = text;
+
+        if (update) {
+            update();
+        }
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setHologram(IHologram hologram) {
+        this.hologram = hologram;
+    }
+
+    @Override
+    public IHologram getHologram() {
+        return hologram;
+    }
+
+    @Override
+    public void update() {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        entity.n(true);
+        update();
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        entity.n(false);
+        update();
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public void reveal() {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R3.sendPacket(hologram.getPlayer(), packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update();
+    }
+
+    @Override
+    public void remove() {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
+        v1_21_R3.sendPacket(hologram.getPlayer(), packet);
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+        remove();
+        hologram.removeLine(this);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
@@ -1,0 +1,285 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Hologram implements IHologram {
+    private final Player p;
+    private List<IHoloLine> lines;
+    private final Location loc;
+    private double gap = 0.25;
+    private boolean showing = true;
+
+    public Hologram(Player p, List<IHoloLine> lines, Location loc) {
+        this.p = p;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    public Player getPlayer() {
+        return this.p;
+    }
+
+    public Hologram(Player p, Location loc, List<String> lines) {
+        this.p = p;
+        this.loc = loc;
+        this.lines = new ArrayList<>();
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line) {
+        this.lines.add(line);
+    }
+
+    @Override
+    public void removeLine(IHoloLine line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public void removeLine(int index) {
+        this.lines.remove(index);
+    }
+
+    @Override
+    public void clearLines() {
+        this.lines.clear();
+    }
+
+    @Override
+    public void update() {
+        for (IHoloLine line : this.lines) {
+            line.update();
+        }
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        for (IHoloLine line : this.lines) {
+            line.show();
+        }
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        for (IHoloLine line : this.lines) {
+            line.hide();
+        }
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public int size() {
+        return this.lines.size();
+    }
+
+    @Override
+    public IHoloLine getLine(int index) {
+        return this.lines.get(index);
+    }
+
+    @Override
+    public List<IHoloLine> getLines() {
+        return this.lines;
+    }
+
+    @Override
+    public Location getLocation() {
+        return this.loc;
+    }
+
+    @Override
+    public void setLines(String[] lines, boolean update) {
+        this.lines.clear();
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLines(List<IHoloLine> lines, boolean update) {
+        this.lines = lines;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line) {
+        this.lines.set(index, line);
+        this.lines.get(index).update();
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line, boolean update) {
+        this.lines.set(index, line);
+        if (update) {
+            this.lines.get(index).update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, String line) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line);
+    }
+
+    @Override
+    public void setLine(int index, String line, boolean update) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line, update);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line) {
+        this.lines.remove(index);
+        this.lines.add(index, line);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line, boolean update) {
+        this.lines.add(index, line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void insertLine(int index, String line) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+    }
+
+    @Override
+    public void insertLine(int index, String line, boolean update) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line, boolean update) {
+        this.lines.add(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(String line) {
+        this.lines.add(new HoloLine(line, this));
+    }
+
+    @Override
+    public void addLine(String line, boolean update) {
+        this.lines.add(new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(IHoloLine line, boolean update) {
+        this.lines.remove(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(int index, boolean update) {
+        this.lines.remove(index);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void clearLines(boolean update) {
+        this.lines.clear();
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setGap(double gap) {
+        this.gap = gap;
+        this.update();
+    }
+
+    @Override
+    public void setGap(double gap, boolean update) {
+        this.gap = gap;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public double getGap() {
+        return this.gap;
+    }
+
+    @Override
+    public void remove() {
+        for (IHoloLine line : this.lines) line.remove();
+        lines.clear();
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -814,7 +814,7 @@ public final class v1_21_R3 extends VersionSupport {
             throw new RuntimeException("World of a location should not be null.");
         }
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
-        nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
         for (Player p : loc.getWorld().getPlayers()) {

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -279,14 +279,7 @@ public final class v1_21_R3 extends VersionSupport {
     public void setSource(TNTPrimed tnt, Player owner) {
         EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
         EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
-        try {
-            Field sourceField = EntityTNTPrimed.class.getDeclaredField("i");
-            sourceField.setAccessible(true);
-            sourceField.set(nmsTNT, nmsEntityLiving);
-        } catch (Exception ex) {
-            //noinspection CallToPrintStackTrace
-            ex.printStackTrace();
-        }
+        nmsTNT.i = nmsEntityLiving;
     }
 
     @Override
@@ -689,20 +682,18 @@ public final class v1_21_R3 extends VersionSupport {
 
     @Override
     public void playRedStoneDot(Player player) {
-        Color color = Color.RED;
-//        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
-//                new ParticleParamRedstone(
-//                        color.asRGB(), (float) 1
-//                ),
-//                true,
-//                player.getLocation().getX(),
-//                player.getLocation().getY() + 2.6,
-//                player.getLocation().getZ(),
-//                0, 0, 0, 0, 0
-//        );
-        for (Player inWorld : player.getWorld().getPlayers()) {
-            if (inWorld.equals(player)) continue;
-//            sendPacket(inWorld, particlePacket);
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                ParticleParamRedstone.b,
+                true,
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player p : player.getWorld().getPlayers()) {
+            if (p.equals(player)) continue;
+            sendPacket(p, particlePacket);
         }
     }
 

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -144,7 +144,7 @@ public final class v1_21_R3 extends VersionSupport {
     public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
         var i = getItem(itemStack);
         if (null == i) return false;
-        return i instanceof ItemArmor || i instanceof ItemElytra;
+        return i instanceof ItemArmor;
     }
 
     @Override
@@ -280,7 +280,7 @@ public final class v1_21_R3 extends VersionSupport {
         EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
         EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
         try {
-            Field sourceField = EntityTNTPrimed.class.getDeclaredField("h");
+            Field sourceField = EntityTNTPrimed.class.getDeclaredField("i");
             sourceField.setAccessible(true);
             sourceField.set(nmsTNT, nmsEntityLiving);
         } catch (Exception ex) {
@@ -348,22 +348,22 @@ public final class v1_21_R3 extends VersionSupport {
     public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
         try {
             // blast resistance
-            Field field = BlockBase.class.getDeclaredField("aH");
+            Field field = BlockBase.class.getDeclaredField("aI");
             field.setAccessible(true);
             // end stone
-            field.set(Blocks.fz, endStoneBlast);
+            field.set(Blocks.fU, endStoneBlast);
             // obsidian
-            field.set(Blocks.co, glassBlast);
+            field.set(Blocks.cv, glassBlast);
             // standard glass
-            field.set(Blocks.aQ, glassBlast);
+            field.set(Blocks.aX, glassBlast);
 
             var coloredGlass = new net.minecraft.world.level.block.Block[]{
-                    Blocks.ei, Blocks.ej, Blocks.ek, Blocks.el,
-                    Blocks.em, Blocks.en, Blocks.eo, Blocks.ep,
-                    Blocks.eq, Blocks.er, Blocks.es, Blocks.et,
-                    Blocks.eu, Blocks.ev, Blocks.ew, Blocks.ex,
+                    Blocks.ev, Blocks.ew, Blocks.ex, Blocks.ey,
+                    Blocks.ez, Blocks.eA, Blocks.eB, Blocks.eC,
+                    Blocks.eD, Blocks.eE, Blocks.eF, Blocks.eG,
+                    Blocks.eH, Blocks.eI, Blocks.eJ, Blocks.eK,
 
-                    Blocks.aQ,
+                    Blocks.aX,
             };
 
             Arrays.stream(coloredGlass).forEach(
@@ -676,7 +676,7 @@ public final class v1_21_R3 extends VersionSupport {
     @Override
     public String getMainLevel() {
         //noinspection deprecation
-        return ((DedicatedServer) MinecraftServer.getServer()).a().n;
+        return ((DedicatedServer) MinecraftServer.getServer()).a().l;
     }
 
     @Override
@@ -688,21 +688,19 @@ public final class v1_21_R3 extends VersionSupport {
     @Override
     public void playRedStoneDot(Player player) {
         Color color = Color.RED;
-        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
-                new ParticleParamRedstone(
-                        new Vector3f((float) color.getRed(),
-                                (float) color.getGreen(),
-                                (float) color.getBlue()), (float) 1
-                ),
-                true,
-                player.getLocation().getX(),
-                player.getLocation().getY() + 2.6,
-                player.getLocation().getZ(),
-                0, 0, 0, 0, 0
-        );
+//        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+//                new ParticleParamRedstone(
+//                        color.asRGB(), (float) 1
+//                ),
+//                true,
+//                player.getLocation().getX(),
+//                player.getLocation().getY() + 2.6,
+//                player.getLocation().getZ(),
+//                0, 0, 0, 0, 0
+//        );
         for (Player inWorld : player.getWorld().getPlayers()) {
             if (inWorld.equals(player)) continue;
-            sendPacket(inWorld, particlePacket);
+//            sendPacket(inWorld, particlePacket);
         }
     }
 
@@ -755,7 +753,7 @@ public final class v1_21_R3 extends VersionSupport {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
         Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
 
@@ -826,11 +824,11 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     public static void sendPacket(Player player, Packet<?> packet) {
-        ((CraftPlayer) player).getHandle().c.b(packet);
+        ((CraftPlayer) player).getHandle().f.b(packet);
     }
 
     public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
-        PlayerConnection connection = ((CraftPlayer) player).getHandle().c;
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().f;
         for (Packet<?> p : packets) {
             connection.b(p);
         }
@@ -844,7 +842,7 @@ public final class v1_21_R3 extends VersionSupport {
         if (null == i) {
             return null;
         }
-        return i.g();
+        return i.h();
     }
 
     /**
@@ -855,7 +853,7 @@ public final class v1_21_R3 extends VersionSupport {
         if (null == i) {
             return null;
         }
-        return i.E();
+        return i.I();
     }
 
     private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
@@ -882,16 +880,16 @@ public final class v1_21_R3 extends VersionSupport {
     public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
         return new PacketPlayOutSpawnEntity(
                 nmsEntity.hashCode(),
-                nmsEntity.cz(),
-                nmsEntity.dt(),
-                nmsEntity.dv(),
-                nmsEntity.dz(),
+                nmsEntity.cG(),
+                nmsEntity.dA(),
+                nmsEntity.dC(),
                 nmsEntity.dG(),
+                nmsEntity.dN(),
                 nmsEntity.getBukkitYaw(),
-                nmsEntity.am(),
+                nmsEntity.aq(),
                 0,
-                nmsEntity.dr(),
-                nmsEntity.ct()
+                nmsEntity.dy(),
+                nmsEntity.cA()
         );
     }
 }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -1,0 +1,897 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R3;
+
+import com.mojang.datafixers.util.Pair;
+import com.saicone.rtag.RtagItem;
+import com.saicone.rtag.util.OptionalType;
+import com.saicone.rtag.util.SkullTexture;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.arena.team.TeamColor;
+import com.tomkeuper.bedwars.api.entity.Despawnable;
+import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
+import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import com.tomkeuper.bedwars.support.version.common.VersionCommon;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable.DespawnableAttributes;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable.DespawnableFactory;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.despawnable.DespawnableType;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.hologram.HoloLine;
+import com.tomkeuper.bedwars.support.version.v1_21_R3.hologram.Hologram;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.core.particles.ParticleParamRedstone;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.entity.item.EntityTNTPrimed;
+import net.minecraft.world.entity.projectile.IProjectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBase;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Ladder;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.v1_21_R3.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R3.entity.*;
+import org.bukkit.craftbukkit.v1_21_R3.inventory.CraftItemStack;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.*;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+
+import static com.tomkeuper.bedwars.api.language.Language.getList;
+
+public final class v1_21_R3 extends VersionSupport {
+
+    private final DespawnableFactory despawnableFactory;
+
+    public v1_21_R3(Plugin plugin, String name) {
+        super(plugin, name);
+        loadDefaultEffects();
+        this.despawnableFactory = new DespawnableFactory(this);
+    }
+
+    @Override
+    public void registerCommand(String name, Command cmd) {
+        ((CraftServer) getPlugin().getServer()).getCommandMap().register(name, cmd);
+    }
+
+    @Override
+    public void sendTitle(Player p, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
+    }
+
+    @Override
+    public void playAction(Player p, String text) {
+        p.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.translateAlternateColorCodes('&', text)
+                )
+        );
+    }
+
+    @Override
+    public boolean isBukkitCommandRegistered(String name) {
+        return ((CraftServer) getPlugin().getServer()).getCommandMap().getCommand(name) != null;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemInHand(@NotNull Player p) {
+        return p.getInventory().getItemInMainHand();
+    }
+
+    @Override
+    public void hideEntity(Entity e, Player p) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(e.getEntityId());
+        sendPacket(p, packet);
+    }
+
+    @Override
+    public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemArmor || i instanceof ItemElytra;
+    }
+
+    @Override
+    public boolean isTool(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemTool;
+    }
+
+    @Override
+    public boolean isSword(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemSword;
+    }
+
+    @Override
+    public boolean isAxe(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemAxe;
+    }
+
+    @Override
+    public boolean isBow(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemBow;
+    }
+
+
+    @Override
+    public boolean isProjectile(org.bukkit.inventory.ItemStack itemStack) {
+        var entity = getEntity(itemStack);
+        if (null == entity) return false;
+        return entity instanceof IProjectile;
+    }
+
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.@NotNull ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
+    public void registerEntities() {
+
+    }
+
+    @Override
+    public void spawnShop(Location loc, String name1, List<Player> players, IArena arena) {
+        Location l = loc.clone();
+
+        if (l.getWorld() == null) return;
+        Villager vlg = (Villager) l.getWorld().spawnEntity(loc, EntityType.VILLAGER);
+        vlg.setAI(false);
+        vlg.setRemoveWhenFarAway(false);
+        vlg.setCollidable(false);
+        vlg.setInvulnerable(true);
+        vlg.setSilent(true);
+    }
+
+    @Override
+    public void spawnShopHologram(Location loc, String name1, List<Player> players, IArena arena, ITeam team) {
+        for (Player p : players) {
+            String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
+            IHologram h = createHologram(p, loc, nume);
+
+            new ShopHolo(h, loc, arena, team);
+        }
+
+        for (Player p : players) {
+            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+        }
+    }
+
+    @Override
+    public double getDamage(org.bukkit.inventory.ItemStack i) {
+        var tag = getTag(i);
+        if (null == tag) {
+            throw new RuntimeException("Provided item has no Tag");
+        }
+        return tag.k("generic.attackDamage");
+    }
+
+    @Override
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+        var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH
+        );
+    }
+
+    @Override
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+        var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM
+        );
+    }
+
+    @Override
+    public void minusAmount(Player p, org.bukkit.inventory.@NotNull ItemStack i, int amount) {
+        if (i.getAmount() - amount <= 0) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
+            return;
+        }
+        i.setAmount(i.getAmount() - amount);
+        //noinspection UnstableApiUsage
+        p.updateInventory();
+    }
+
+    @Override
+    public void setSource(TNTPrimed tnt, Player owner) {
+        EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
+        EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
+        try {
+            Field sourceField = EntityTNTPrimed.class.getDeclaredField("h");
+            sourceField.setAccessible(true);
+            sourceField.set(nmsTNT, nmsEntityLiving);
+        } catch (Exception ex) {
+            //noinspection CallToPrintStackTrace
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void voidKill(Player p) {
+        @SuppressWarnings("UnstableApiUsage")
+        EntityDamageEvent event = new EntityDamageEvent(p, EntityDamageEvent.DamageCause.VOID, DamageSource.builder(DamageType.GENERIC).build(), 1000.0);
+        //noinspection removal
+        p.setLastDamageCause(event);
+        p.setHealth(0);
+    }
+
+    @Override
+    public void hideArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public void showArmor(Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(victim.getInventory().getHelmet())));
+        items.add(new Pair<>(EnumItemSlot.e, CraftItemStack.asNMSCopy(victim.getInventory().getChestplate())));
+        items.add(new Pair<>(EnumItemSlot.d, CraftItemStack.asNMSCopy(victim.getInventory().getLeggings())));
+        items.add(new Pair<>(EnumItemSlot.c, CraftItemStack.asNMSCopy(victim.getInventory().getBoots())));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public EnderDragon spawnDragon(Location l, ITeam team) {
+        if (l == null || l.getWorld() == null) {
+            getPlugin().getLogger().log(Level.WARNING, "Could not spawn Dragon. Location is null");
+            return null;
+        }
+        EnderDragon ed = (EnderDragon) l.getWorld().spawnEntity(l, EntityType.ENDER_DRAGON);
+        ed.setPhase(EnderDragon.Phase.CIRCLING);
+        return ed;
+    }
+
+    @Override
+    public void colorBed(ITeam bwt) {
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
+                if (bed instanceof Bed) {
+                    bed.setType(bwt.getColor().bedMaterial());
+                    bed.update();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
+        try {
+            // blast resistance
+            Field field = BlockBase.class.getDeclaredField("aH");
+            field.setAccessible(true);
+            // end stone
+            field.set(Blocks.fz, endStoneBlast);
+            // obsidian
+            field.set(Blocks.co, glassBlast);
+            // standard glass
+            field.set(Blocks.aQ, glassBlast);
+
+            var coloredGlass = new net.minecraft.world.level.block.Block[]{
+                    Blocks.ei, Blocks.ej, Blocks.ek, Blocks.el,
+                    Blocks.em, Blocks.en, Blocks.eo, Blocks.ep,
+                    Blocks.eq, Blocks.er, Blocks.es, Blocks.et,
+                    Blocks.eu, Blocks.ev, Blocks.ew, Blocks.ex,
+
+                    Blocks.aQ,
+            };
+
+            Arrays.stream(coloredGlass).forEach(
+                    glass -> {
+                        try {
+                            field.set(glass, glassBlast);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            //noinspection CallToPrintStackTrace
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void setBlockTeamColor(Block block, TeamColor teamColor) {
+        if (block.getType().toString().contains("STAINED_GLASS") || block.getType().toString().equals("GLASS")) {
+            block.setType(teamColor.glassMaterial());
+        } else if (block.getType().toString().contains("_TERRACOTTA")) {
+            block.setType(teamColor.glazedTerracottaMaterial());
+        } else if (block.getType().toString().contains("_WOOL")) {
+            block.setType(teamColor.woolMaterial());
+        }
+    }
+
+    @Override
+    public void setCollide(Player p, IArena a, boolean value) {
+        p.setCollidable(value);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addCustomData(org.bukkit.inventory.ItemStack i, String data) {
+        return RtagItem.edit(i, tag -> {
+            tag.set(data, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        });
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {
+        return RtagItem.edit(itemStack, tag -> {
+            tag.set(value, key);
+        });
+    }
+
+    @Override
+    public String getTag(org.bukkit.inventory.ItemStack itemStack, String key) {
+        var tag = getTag(itemStack);
+        return tag == null ? null : tag.e(key) ? tag.l(key) : null;
+    }
+
+    @Override
+    public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return tag.isNotEmpty();
+    }
+
+    @Override
+    public String getCustomData(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return (tag.isEmpty() || tag.isNotInstance(String.class)) ? null : tag.asString(null);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack colourItem(org.bukkit.inventory.ItemStack itemStack, ITeam bedWarsTeam) {
+        if (itemStack == null) return null;
+        String type = itemStack.getType().toString();
+        if (isBed(itemStack.getType())) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().bedMaterial(), itemStack.getAmount());
+        } else if (type.contains("_STAINED_GLASS_PANE")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassPaneMaterial(), itemStack.getAmount());
+        } else if (type.contains("STAINED_GLASS") || type.equals("GLASS")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassMaterial(), itemStack.getAmount());
+        } else if (type.contains("_TERRACOTTA")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glazedTerracottaMaterial(), itemStack.getAmount());
+        } else if (type.contains("_WOOL")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().woolMaterial(), itemStack.getAmount());
+        }
+        return itemStack;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack createItemStack(String material, int amount, short data) {
+        org.bukkit.inventory.ItemStack i;
+        try {
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.valueOf(material), amount);
+        } catch (Exception ex) {
+            getPlugin().getLogger().log(Level.WARNING, material + " is not a valid " + getName() + " material!");
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.BEDROCK);
+        }
+        return i;
+    }
+
+    @Override
+    public Material materialFireball() {
+        return org.bukkit.Material.FIRE_CHARGE;
+    }
+
+    @Override
+    public org.bukkit.Material materialPlayerHead() {
+        return org.bukkit.Material.PLAYER_HEAD;
+    }
+
+    @Override
+    public org.bukkit.Material materialSnowball() {
+        return org.bukkit.Material.SNOWBALL;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenHelmet() {
+        return org.bukkit.Material.GOLDEN_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenChestPlate() {
+        return org.bukkit.Material.GOLDEN_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenLeggings() {
+        return org.bukkit.Material.GOLDEN_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteHelmet() {
+        return Material.NETHERITE_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteChestPlate() {
+        return Material.NETHERITE_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteLeggings() {
+        return Material.NETHERITE_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialElytra() {
+        return Material.ELYTRA;
+    }
+
+    @Override
+    public org.bukkit.Material materialCake() {
+        return org.bukkit.Material.CAKE;
+    }
+
+    @Override
+    public org.bukkit.Material materialCraftingTable() {
+        return org.bukkit.Material.CRAFTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEnchantingTable() {
+        return org.bukkit.Material.ENCHANTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEndStone() {
+        return Material.END_STONE;
+    }
+
+    @Override
+    public org.bukkit.Material woolMaterial() {
+        return org.bukkit.Material.WHITE_WOOL;
+    }
+
+    @Override
+    public void setJoinSignBackground(BlockState b, Material material) {
+        if (b.getBlockData() instanceof WallSign) {
+            b.getBlock().getRelative(((WallSign) b.getBlockData()).getFacing().getOppositeFace()).setType(material);
+        }
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack redGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.RED_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack greenGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.LIME_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public String getShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem item = new RtagItem(itemStack);
+        OptionalType tag = item.getOptional(VersionSupport.PLUGIN_TAG_TIER_KEY);
+        return tag.isEmpty() ? "null" : tag.asString("null");
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack, String identifier) {
+        RtagItem item = new RtagItem(itemStack);
+        item.set(identifier, VersionSupport.PLUGIN_TAG_TIER_KEY);
+        item.load();
+        return item.getItem();
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getPlayerHead(Player player, org.bukkit.inventory.ItemStack copyTagFrom) {
+        org.bukkit.inventory.ItemStack head = SkullTexture.getTexturedHead(player.getUniqueId().toString());
+
+        if (copyTagFrom != null) {
+            var tag = getTag(copyTagFrom);
+            RtagItem rtagItem = new RtagItem(head);
+            rtagItem.set(tag, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+            rtagItem.load();
+            head = rtagItem.getItem();
+        }
+
+        return head;
+    }
+
+    @Override
+    public void sendPlayerSpawnPackets(Player respawned, IArena arena) {
+        if (respawned == null) return;
+        if (arena == null) return;
+        if (!arena.isPlayer(respawned)) return;
+
+        // if method was used when the player was still in re-spawning screen
+        if (arena.getRespawnSessions().containsKey(respawned)) return;
+
+        EntityPlayer entityPlayer = getPlayer(respawned);
+        PacketPlayOutSpawnEntity show = newPacketPlayOutSpawnEntity(entityPlayer);
+        PacketPlayOutEntityVelocity playerVelocity = new PacketPlayOutEntityVelocity(entityPlayer);
+        // we send head rotation packet because sometimes on respawn others see him with bad rotation
+        PacketPlayOutEntityHeadRotation head = new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()));
+
+        // retrieve current armor and in-hand items
+        // we send a packet later for timing issues where other players do not see them
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = getPlayerEquipment(entityPlayer);
+
+
+        for (Player p : arena.getPlayers()) {
+            if (p == null) continue;
+            if (p.equals(respawned)) continue;
+            // if p is in re-spawning screen continue
+            if (arena.getRespawnSessions().containsKey(p)) continue;
+
+            EntityPlayer boundTo = getPlayer(p);
+            if (p.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(p.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to regular players
+                    sendPackets(
+                            p, show, head, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list)
+                    );
+
+                    // send nearby players to respawned player
+                    // if the player has invisibility hide armor
+                    if (p.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                        hideArmor(p, respawned);
+                    } else {
+                        PacketPlayOutSpawnEntity show2 = newPacketPlayOutSpawnEntity(boundTo);
+
+                        PacketPlayOutEntityVelocity playerVelocity2 = new PacketPlayOutEntityVelocity(boundTo);
+                        PacketPlayOutEntityHeadRotation head2 = new PacketPlayOutEntityHeadRotation(boundTo, getCompressedAngle(boundTo.getBukkitYaw()));
+                        sendPackets(respawned, show2, playerVelocity2, head2);
+                        showArmor(p, respawned);
+                    }
+                }
+            }
+        }
+
+        for (Player spectator : arena.getSpectators()) {
+            if (spectator == null) continue;
+            if (spectator.equals(respawned)) continue;
+            respawned.hidePlayer(getPlugin(), spectator);
+            if (spectator.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(spectator.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to spectator
+                    sendPackets(
+                            spectator, show, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list),
+                            new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()))
+                    );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getInventoryName(@NotNull InventoryEvent e) {
+        return e.getView().getTitle();
+    }
+
+    @Override
+    public void setUnbreakable(ItemMeta itemMeta) {
+        itemMeta.setUnbreakable(true);
+    }
+
+    @Override
+    public int getVersion() {
+        return 12;
+    }
+
+    @Override
+    public void registerVersionListeners() {
+        new VersionCommon(this);
+    }
+
+    @Override
+    public String getMainLevel() {
+        //noinspection deprecation
+        return ((DedicatedServer) MinecraftServer.getServer()).a().n;
+    }
+
+    @Override
+    public Fireball setFireballDirection(Fireball fireball, Vector vector) {
+        fireball.setDirection(vector);
+        return fireball;
+    }
+
+    @Override
+    public void playRedStoneDot(Player player) {
+        Color color = Color.RED;
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                new ParticleParamRedstone(
+                        new Vector3f((float) color.getRed(),
+                                (float) color.getGreen(),
+                                (float) color.getBlue()), (float) 1
+                ),
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player inWorld : player.getWorld().getPlayers()) {
+            if (inWorld.equals(player)) continue;
+            sendPacket(inWorld, particlePacket);
+        }
+    }
+
+    @Override
+    public void clearArrowsFromPlayerBody(Player player) {
+        // minecraft clears them on death on newer version
+    }
+
+    @Override
+    public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
+        b.getRelative(x, y, z).setType(color.woolMaterial());
+        a.addPlacedBlock(b.getRelative(x, y, z));
+        return b.getRelative(x, y, z);
+    }
+
+    @Override
+    public Block placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
+        Block block = b.getRelative(x, y, z);  //ladder block
+        block.setType(Material.LADDER);
+        Ladder ladder = (Ladder) block.getBlockData();
+        a.addPlacedBlock(block);
+        switch (ladderData) {
+            case 2 -> {
+                ladder.setFacing(BlockFace.NORTH);
+                block.setBlockData(ladder);
+            }
+            case 3 -> {
+                ladder.setFacing(BlockFace.SOUTH);
+                block.setBlockData(ladder);
+            }
+            case 4 -> {
+                ladder.setFacing(BlockFace.WEST);
+                block.setBlockData(ladder);
+            }
+            case 5 -> {
+                ladder.setFacing(BlockFace.EAST);
+                block.setBlockData(ladder);
+            }
+        }
+        return b;
+    }
+
+    @Override
+    public void playVillagerEffect(Player player, Location location) {
+        player.spawnParticle(Particle.HAPPY_VILLAGER, location, 1);
+    }
+
+    @Override
+    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, location, linesList);
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, linesList, location);
+    }
+
+    @Override
+    public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
+        return new HoloLine(text, hologram);
+    }
+
+    @Override
+    public IGeneratorAnimation createDefaultGeneratorAnimation(ArmorStand armorStand) {
+        return new DefaultGenAnimation(armorStand);
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, destroy);
+        }
+    }
+
+    @Override
+    public ArmorStand createPacketArmorStand(Location loc) {
+        if (loc.getWorld() == null) {
+            throw new RuntimeException("World of a location should not be null.");
+        }
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+
+        for (Player p : loc.getWorld().getPlayers()) {
+            sendPacket(p, spawn);
+        }
+        return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);
+    }
+
+    public static void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().c.b(packet);
+    }
+
+    public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().c;
+        for (Packet<?> p : packets) {
+            connection.b(p);
+        }
+    }
+
+    /**
+     * Gets the NMS Item from ItemStack
+     */
+    private @Nullable Item getItem(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.g();
+    }
+
+    /**
+     * Gets the NMS Entity from ItemStack
+     */
+    private @Nullable net.minecraft.world.entity.Entity getEntity(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.E();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem rtagItem = new RtagItem(itemStack);
+        return (NBTTagCompound) rtagItem.getTag();
+    }
+
+    public EntityPlayer getPlayer(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    public List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> getPlayerEquipment(@NotNull EntityPlayer entityPlayer) {
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = new ArrayList<>();
+        list.add(new Pair<>(EnumItemSlot.a, entityPlayer.a(EnumItemSlot.a)));
+        list.add(new Pair<>(EnumItemSlot.b, entityPlayer.a(EnumItemSlot.b)));
+        list.add(new Pair<>(EnumItemSlot.f, entityPlayer.a(EnumItemSlot.f)));
+        list.add(new Pair<>(EnumItemSlot.e, entityPlayer.a(EnumItemSlot.e)));
+        list.add(new Pair<>(EnumItemSlot.d, entityPlayer.a(EnumItemSlot.d)));
+        list.add(new Pair<>(EnumItemSlot.c, entityPlayer.a(EnumItemSlot.c)));
+
+        return list;
+    }
+
+    public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
+        return new PacketPlayOutSpawnEntity(
+                nmsEntity.hashCode(),
+                nmsEntity.cz(),
+                nmsEntity.dt(),
+                nmsEntity.dv(),
+                nmsEntity.dz(),
+                nmsEntity.dG(),
+                nmsEntity.getBukkitYaw(),
+                nmsEntity.am(),
+                0,
+                nmsEntity.dr(),
+                nmsEntity.ct()
+        );
+    }
+}

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -144,7 +144,7 @@ public final class v1_21_R3 extends VersionSupport {
     public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
         var i = getItem(itemStack);
         if (null == i) return false;
-        return i instanceof ItemArmor;
+        return i instanceof ItemArmor || itemStack.getType() == materialElytra();
     }
 
     @Override

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -419,6 +419,8 @@ public final class v1_21_R3 extends VersionSupport {
 
     @Override
     public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        if (i == null) return false;
+        if (i.getType() == org.bukkit.Material.AIR) return false;
         RtagItem rtagItem = new RtagItem(i);
         OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
         return tag.isNotEmpty();


### PR DESCRIPTION
## Admission Tests

### Regular
- [x] You must not be able to drop the default wooden sword
- [x] You must not be able to break your own bed
- [x] You must not be able to take off your armor
- [x] You must be able to break blocks placed by players
- [x] You must not be able to place blocks in team-spawn region
- [x] You must not be able to damage shopkeepers
- [x] Shopkeepers must not be targeted by Silverfishes or Iron Golems
- [x] You must not be targeted by your own Silverfishes or Iron Golems

### Console
- [x] No errors when placing TNT
- [x] No errors when respawning players
- [x] There must be no errors at server start up
- [x] No errors during regular match

### Visual 
- [x] TNT Spoil Feature must show RED particles over your head
- [x] Team upgrades are announced in chat
- [x] You must not be seen by other players while you are in a re-spawning phase

### Blast Protection
- [x] Regular Glass
- [x] Colored Glass
- [x] Obsidian
- [x] Endstone (Fireball)
- [x] Wool covered with Glass or Stained Glass must not explode

## Check while updating nms code
- [x] Check if previously inaccessible fields are now accessible
