### PR TITLE
v1_21_R5, rtag:1.5.11, FireballListener: Catch IllegalArgumentException

### DIFF
--- a/bedwars-plugin/build.gradle.kts
+++ b/bedwars-plugin/build.gradle.kts
@@ -81,10 +81,10 @@ dependencies {
     compileOnly("de.dytanic.cloudnet:cloudnet-wrapper-jvm:3.4.5-RELEASE")
     slim("redis.clients:jedis:5.0.2")
     slim("com.flowpowered:flow-nbt:2.0.2")
-    slim("com.saicone.rtag:rtag:1.5.10")
-    slim("com.saicone.rtag:rtag-block:1.5.10")
-    slim("com.saicone.rtag:rtag-entity:1.5.10")
-    slim("com.saicone.rtag:rtag-item:1.5.10")
+    slim("com.saicone.rtag:rtag:1.5.11")
+    slim("com.saicone.rtag:rtag-block:1.5.11")
+    slim("com.saicone.rtag:rtag-entity:1.5.11")
+    slim("com.saicone.rtag:rtag-item:1.5.11")
 }
 
 
@@ -138,6 +138,7 @@ val versions = setOf(
     ":versionsupport_v1_21_r1",
     ":versionsupport_v1_21_r2",
     ":versionsupport_v1_21_r3",
+    ":versionsupport_v1_21_r5",
     ":resetadapter_slime",
     ":resetadapter_slimepaper",
     ":resetadapter_advancedslimepaper",

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -241,7 +241,13 @@ public class BedWars extends JavaPlugin {
                 nmsVersion = "v1_21_R2";
                 break;
             case "1.21.4":
-                nmsVersion = "v1_21_R3";
+                nmsVersion = "v1_21_R4";
+                break;
+            case "1.21.5":
+            case "1.21.6":
+            case "1.21.7":
+            case "1.21.8":
+                nmsVersion = "v1_21_R5";
                 break;
             default:
                 break;

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -241,12 +241,9 @@ public class BedWars extends JavaPlugin {
                 nmsVersion = "v1_21_R2";
                 break;
             case "1.21.4":
-                nmsVersion = "v1_21_R4";
+                nmsVersion = "v1_21_R3";
                 break;
-            case "1.21.5":
-            case "1.21.6":
             case "1.21.7":
-            case "1.21.8":
                 nmsVersion = "v1_21_R5";
                 break;
             default:

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -245,6 +245,7 @@ public class BedWars extends JavaPlugin {
                 break;
             case "1.21.6":
             case "1.21.7":
+            case "1.21.8":
                 nmsVersion = "v1_21_R5";
                 break;
             default:

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -243,6 +243,7 @@ public class BedWars extends JavaPlugin {
             case "1.21.4":
                 nmsVersion = "v1_21_R3";
                 break;
+            case "1.21.6":
             case "1.21.7":
                 nmsVersion = "v1_21_R5";
                 break;

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/SpectatorListeners.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/SpectatorListeners.java
@@ -149,9 +149,11 @@ public class SpectatorListeners implements Listener {
     @EventHandler
     // Refresh placeholders from GUIs
     public void onPlayerLeave(PlayerLeaveArenaEvent e) {
-        if (e.getArena().isPlayer(e.getPlayer())) {
-            TeleporterGUI.refreshAllGUIs();
-        }
+        Bukkit.getScheduler().runTask(BedWars.plugin, () -> {
+            if (e.getArena().isPlayer(e.getPlayer())) {
+                TeleporterGUI.refreshAllGUIs();
+            }
+        });
     }
 
     @EventHandler

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/spectator/TeleporterGUI.java
@@ -69,6 +69,16 @@ public class TeleporterGUI {
         }
 
         List<Player> players = arena.getPlayers();
+        // Filter out spectators to avoid showing heads for players who became spectators
+        List<Player> nonSpectators = new ArrayList<>();
+        for (Player pl : players) {
+            if (!arena.isSpectator(pl)) {
+                nonSpectators.add(pl);
+            } else {
+                BedWars.debug("SHOULD NOT HAPPEN: Removing spectator " + pl.getName() + " from Teleporter GUI for player " + p.getName());
+            }
+        }
+
         String[] slotStrings = BedWars.config.getYml().getString(ConfigPath.GENERAL_CONFIGURATION_TELEPORTER_SLOTS).split(",");
         List<Integer> slots = new ArrayList<>();
         for (String slot : slotStrings) {
@@ -81,7 +91,7 @@ public class TeleporterGUI {
 
         for (int i = 0; i < slots.size(); i++) {
             if (i < players.size()) {
-                inv.setItem(slots.get(i), createHead(players.get(i), p));
+                inv.setItem(slots.get(i), createHead(nonSpectators.get(i), p));
             } else {
                 inv.setItem(slots.get(i), new ItemStack(Material.AIR));
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
@@ -20,6 +20,7 @@
 
 package com.tomkeuper.bedwars.configuration;
 
+import com.tomkeuper.bedwars.BedWars;
 import com.tomkeuper.bedwars.api.configuration.ConfigManager;
 import com.tomkeuper.bedwars.api.configuration.ConfigPath;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -64,7 +65,9 @@ public class ArenaConfig extends ConfigManager {
         rules.add("doImmediateRespawn:true");
         rules.add("doWeatherCycle:false");
         rules.add("doFireTick:false");
-        rules.add("locatorBar:false");
+        if (BedWars.nms.getVersion() >= 14) {
+            rules.add("locatorBar:false"); // Only apply for 1.21.6 and above
+        }
         yml.addDefault(ConfigPath.ARENA_GAME_RULES, rules);
         yml.options().copyDefaults(true);
         save();

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/ArenaConfig.java
@@ -64,6 +64,7 @@ public class ArenaConfig extends ConfigManager {
         rules.add("doImmediateRespawn:true");
         rules.add("doWeatherCycle:false");
         rules.add("doFireTick:false");
+        rules.add("locatorBar:false");
         yml.addDefault(ConfigPath.ARENA_GAME_RULES, rules);
         yml.options().copyDefaults(true);
         save();

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -32,6 +32,7 @@ import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.arena.Arena;
 import com.tomkeuper.bedwars.arena.LastHit;
 import com.tomkeuper.bedwars.arena.team.BedWarsTeam;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -170,7 +171,9 @@ public class FireballListener implements Listener {
             try {
                 player.setVelocity(horizontalVector.setY(y));
             } catch (IllegalArgumentException ex) {
-                // TODO: implement proper fix for Caused by: java.lang.IllegalArgumentException: x not finite
+                // TODO: implement proper fix for Caused by: java.lang.IllegalArgumentException: x not finite - Logging now!
+                Bukkit.getLogger().severe("IllegalArgumentException has been caught! Horizontal vector is: " + horizontalVector + " with Y being: " + y);
+                Bukkit.getLogger().severe("Player is: " + player.getName() + " and source is: " + source.getName() + " at " + player.getLocation());
             }
 
             LastHit lh = LastHit.getLastHit(player);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -166,7 +166,12 @@ public class FireballListener implements Listener {
             } else {
                 y = y * fireballVertical * 1.5; // kb for jumping
             }
-            player.setVelocity(horizontalVector.setY(y));
+
+            try {
+                player.setVelocity(horizontalVector.setY(y));
+            } catch (IllegalArgumentException ex) {
+                // TODO: implement proper fix for Caused by: java.lang.IllegalArgumentException: x not finite
+            }
 
             LastHit lh = LastHit.getLastHit(player);
             if (lh != null) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ val versions = setOf(
     ":versionsupport_v1_21_r1",
     ":versionsupport_v1_21_r2",
     ":versionsupport_v1_21_r3",
+    ":versionsupport_v1_21_r5",
     ":resetadapter_slime",
     ":resetadapter_slimepaper",
     ":resetadapter_advancedslimepaper",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include(":versionsupport_v1_20_6")
 include(":versionsupport_v1_21_r1")
 include(":versionsupport_v1_21_r2")
 include(":versionsupport_v1_21_r3")
+include(":versionsupport_v1_21_r5")
 include(":versionsupport_common")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/versionsupport_v1_20_6/build.gradle.kts
+++ b/versionsupport_v1_20_6/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.20.6-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.10")
+    compileOnly("com.saicone.rtag:rtag:1.5.11")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.10")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.11")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_20_r4/build.gradle.kts
+++ b/versionsupport_v1_20_r4/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.20.5-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.10")
+    compileOnly("com.saicone.rtag:rtag:1.5.11")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.10")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.11")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r1/build.gradle.kts
+++ b/versionsupport_v1_21_r1/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.21.1-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.10")
+    compileOnly("com.saicone.rtag:rtag:1.5.11")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.10")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.11")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r3/build.gradle.kts
+++ b/versionsupport_v1_21_r3/build.gradle.kts
@@ -4,11 +4,11 @@ dependencies {
     compileOnly("org.spigotmc:spigot:1.21.4-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
-    compileOnly("com.saicone.rtag:rtag:1.5.10")
+    compileOnly("com.saicone.rtag:rtag:1.5.11")
     // Other modules
-    compileOnly("com.saicone.rtag:rtag-block:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-entity:1.5.10")
-    compileOnly("com.saicone.rtag:rtag-item:1.5.10")
+    compileOnly("com.saicone.rtag:rtag-block:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-entity:1.5.11")
+    compileOnly("com.saicone.rtag:rtag-item:1.5.11")
 }
 
 tasks.compileJava {

--- a/versionsupport_v1_21_r5/build.gradle.kts
+++ b/versionsupport_v1_21_r5/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     compileOnly(projects.bedwarsApi)
     implementation(projects.versionsupportCommon)
-    compileOnly("org.spigotmc:spigot:1.21.3-R0.1-SNAPSHOT") {
+    compileOnly("org.spigotmc:spigot:1.21.7-R0.1-SNAPSHOT") {
         exclude("commons-lang", "commons-lang")
     }
     compileOnly("com.saicone.rtag:rtag:1.5.11")
@@ -24,4 +24,4 @@ repositories {
     maven("https://jitpack.io") // Jitpack (RTag)
 }
 
-description = "versionsupport_v1_21_r2"
+description = "versionsupport_v1_21_r5"

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/DefaultGenAnimation.java
@@ -1,0 +1,119 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5;
+
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import net.minecraft.network.protocol.game.PacketPlayOutEntity;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftArmorStand;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultGenAnimation implements IGeneratorAnimation {
+
+    private final Entity armorStand;
+    private final Location loc;
+    private int tickCount = 0; // A counter to keep track of the ticks since the animation started.
+
+    // Constants for the sinusoidal motion
+    final double frequency = 0.035; // Controls the oscillation speed.
+    final double amplitude = 260; // Controls the range of YAW motion.
+    final double verticalAmplitude = 0.15; // Controls the range of vertical motion.
+
+    public DefaultGenAnimation(ArmorStand armorStand) {
+        this.armorStand = ((CraftArmorStand) armorStand).getHandle();
+        this.loc = armorStand.getLocation();
+        setArmorStandYAW(0);
+        setArmorStandMotY(0);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "bw2023:default";
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("BedWars2023");
+    }
+
+    @Override
+    public void run() {
+        // Calculate sinusoidal values for YAW and MotY
+        float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
+        float sinusoidalMotY = (float) (Math.sin((frequency * tickCount) + Math.PI/2) * verticalAmplitude);
+
+        // Update the armor stand's YAW and MotY based on the sinusoidal functions
+        final double lastMotY = getArmorStandMotY();
+        setArmorStandYAW(sinusoidalYaw);
+        addArmorStandMotY(sinusoidalMotY);
+
+        armorStand.o(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
+        armorStand.bb = false; // SETTING ON GROUND TO FALSE
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(armorStand.dw(), delta, 0, 0);
+        final Set<Relative> set = new HashSet<>();
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.ar(), positionMoveRotation, set, false);
+
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            v1_21_R5.sendPackets(p, teleportPacket, moveLookPacket);
+        }
+        tickCount++;
+    }
+
+    private void setArmorStandYAW(float yaw) {
+        armorStand.v(yaw);
+    }
+
+    private void addArmorStandYAW(float yaw) {
+        armorStand.v(getArmorStandYAW() + yaw);
+    }
+
+    private float getArmorStandYAW() {
+        return armorStand.dP();
+    }
+
+    private void setArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, y, 0));
+    }
+
+    private void addArmorStandMotY(double y) {
+        armorStand.i(new Vec3D(0, getArmorStandMotY() + y, 0));
+    }
+
+    private double getArmorStandMotY() {
+        return armorStand.ae().e;
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
+
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableFactory.java
@@ -1,0 +1,47 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DespawnableFactory {
+
+    private final VersionSupport versionSupport;
+    private final List<DespawnableProvider<? extends LivingEntity>> providers = new ArrayList<>();
+
+    public DespawnableFactory(VersionSupport versionSupport) {
+        this.versionSupport = versionSupport;
+        providers.add(new TeamIronGolem());
+        providers.add(new TeamSilverfish());
+    }
+
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+        return providers.stream().filter(provider -> provider.getType() == attr.type())
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableProvider.java
@@ -1,0 +1,92 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.EntityInsentient;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.ai.attributes.GenericAttributes;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalSelector;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalNearestAttackableTarget;
+import net.minecraft.world.entity.player.EntityHuman;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public abstract class DespawnableProvider<T> {
+
+    abstract DespawnableType getType();
+
+    abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
+
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+
+    protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
+        var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
+        return null == despawnable || despawnable.getTeam() != team;
+    }
+
+    protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.ci;
+    }
+
+    protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.ch;
+    }
+
+    protected void clearSelectors(@NotNull EntityCreature entityLiving) {
+        entityLiving.ci.b().clear();
+        entityLiving.ch.b().clear();
+    }
+
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+                (entityLiving, sourceEntity) -> { // Two parameters now
+                    if (entityLiving instanceof EntityHuman) {
+                        return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
+                                !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
+                                !team.getArena().isReSpawning(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId())
+                                && !team.getArena().isSpectator(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId());
+                    }
+                    return notSameTeam(entityLiving, team, api);
+                });
+    }
+
+    protected void applyDefaultSettings(org.bukkit.entity.@NotNull LivingEntity bukkitEntity, DespawnableAttributes attr,
+                                        ITeam team) {
+        bukkitEntity.setRemoveWhenFarAway(false);
+        bukkitEntity.setPersistent(true);
+        bukkitEntity.setCustomNameVisible(true);
+        bukkitEntity.setCustomName(getDisplayName(attr, team));
+
+        var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
+
+        Objects.requireNonNull(entity.fg().a(GenericAttributes.t)).a(attr.health());
+        Objects.requireNonNull(entity.fg().a(GenericAttributes.w)).a(attr.speed());
+        Objects.requireNonNull(entity.fg().a(GenericAttributes.c)).a(attr.damage());
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableType.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableType.java
@@ -1,0 +1,26 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+public enum DespawnableType {
+    IRON_GOLEM,
+    SILVERFISH
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamIronGolem.java
@@ -1,0 +1,78 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.animal.EntityIronGolem;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamIronGolem extends DespawnableProvider<IronGolem> {
+
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.IRON_GOLEM;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+
+        var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntityIronGolem) ((CraftEntity) bukkitEntity).getHandle();
+
+        clearSelectors(entity);
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.5D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamSilverfish.java
@@ -1,0 +1,76 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.monster.EntitySilverfish;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamSilverfish extends DespawnableProvider<Silverfish> {
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.SILVERFISH;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    @Override
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+        var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntitySilverfish) ((CraftEntity) bukkitEntity).getHandle();
+        clearSelectors(entity);
+
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.9D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
@@ -1,0 +1,144 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.v1_21_R5;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R5.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R5.util.CraftChatMessage;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class HoloLine implements IHoloLine {
+    private String text;
+    private IHologram hologram;
+    public final EntityArmorStand entity;
+    private boolean destroyed = false;
+
+    public HoloLine(String text, IHologram hologram) {
+        this.text = text;
+        this.hologram = hologram;
+        entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        entity.p(true);
+        entity.k(true);
+        entity.ag = true;
+        Location loc = hologram.getLocation();
+        entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
+
+        PacketPlayOutSpawnEntity packet = v1_21_R5.newPacketPlayOutSpawnEntity(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R5.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void setText(String text) {
+        this.text = text;
+        update();
+    }
+
+    @Override
+    public void setText(String text, boolean update) {
+        this.text = text;
+
+        if (update) {
+            update();
+        }
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setHologram(IHologram hologram) {
+        this.hologram = hologram;
+    }
+
+    @Override
+    public IHologram getHologram() {
+        return hologram;
+    }
+
+    @Override
+    public void update() {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R5.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void reveal() {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R5.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R5.sendPacket(hologram.getPlayer(), packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update();
+    }
+
+    @Override
+    public void remove() {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
+        v1_21_R5.sendPacket(hologram.getPlayer(), packet);
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+        remove();
+        hologram.removeLine(this);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
@@ -48,20 +48,20 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.p(true);
-        entity.k(true);
-        entity.ag = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.p(true); // setCustomNameVisible
+        entity.l(true); // setInvisible
+        entity.aq = true; // noPhysics
         Location loc = hologram.getLocation();
-        entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
+        entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ()); // setPosRaw
 
         PacketPlayOutSpawnEntity packet = v1_21_R5.newPacketPlayOutSpawnEntity(entity);
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c()); // getId(), getEntityData()
 
         final var delta = new Vec3D(0,0,0);
-        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR());
+        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR()); // trackingPosition(), , , getXRot()
         final Set<Relative> set = new HashSet<>();
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(), positionMoveRotation, set, false);
 
         v1_21_R5.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
     }
@@ -98,17 +98,17 @@ public class HoloLine implements IHoloLine {
 
     @Override
     public void update() {
-        entity.b(CraftChatMessage.fromStringOrNull(text));
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
         int position = hologram.getLines().indexOf(this);
-        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ()); //
         if (isDestroyed()) return;
 
-        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c()); // getId(), getEntityData()
 
         final var delta = new Vec3D(0,0,0);
-        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR());
+        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR()); // trackingPosition(), , , getXRot()
         final Set<Relative> set = new HashSet<>();
-        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(), positionMoveRotation, set, false); // getId()
 
         v1_21_R5.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
     }

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
@@ -1,0 +1,295 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Hologram implements IHologram {
+    private final Player p;
+    private List<IHoloLine> lines;
+    private final Location loc;
+    private double gap = 0.25;
+    private boolean showing = true;
+
+    public Hologram(Player p, List<IHoloLine> lines, Location loc) {
+        this.p = p;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    public Player getPlayer() {
+        return this.p;
+    }
+
+    public Hologram(Player p, Location loc, List<String> lines) {
+        this.p = p;
+        this.loc = loc;
+        this.lines = new ArrayList<>();
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line) {
+        this.lines.add(line);
+    }
+
+    @Override
+    public void removeLine(IHoloLine line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public void removeLine(int index) {
+        this.lines.remove(index);
+    }
+
+    @Override
+    public void removeLineContaining(String text) {
+        for (IHoloLine line : this.lines) {
+            if (line.getText().contains(text)) {
+                line.remove();
+                break; // Only remove 1 line
+            }
+        }
+    }
+
+    @Override
+    public void clearLines() {
+        this.lines.clear();
+    }
+
+    @Override
+    public void update() {
+        for (IHoloLine line : this.lines) {
+            line.update();
+        }
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        for (IHoloLine line : this.lines) {
+            line.reveal();
+        }
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        for (IHoloLine line : this.lines) {
+            line.remove();
+        }
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public int size() {
+        return this.lines.size();
+    }
+
+    @Override
+    public IHoloLine getLine(int index) {
+        return this.lines.get(index);
+    }
+
+    @Override
+    public List<IHoloLine> getLines() {
+        return this.lines;
+    }
+
+    @Override
+    public Location getLocation() {
+        return this.loc;
+    }
+
+    @Override
+    public void setLines(String[] lines, boolean update) {
+        this.lines.clear();
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLines(List<IHoloLine> lines, boolean update) {
+        this.lines = lines;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line) {
+        this.lines.set(index, line);
+        this.lines.get(index).update();
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line, boolean update) {
+        this.lines.set(index, line);
+        if (update) {
+            this.lines.get(index).update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, String line) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line);
+    }
+
+    @Override
+    public void setLine(int index, String line, boolean update) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line, update);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line) {
+        this.lines.remove(index);
+        this.lines.add(index, line);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line, boolean update) {
+        this.lines.add(index, line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void insertLine(int index, String line) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+    }
+
+    @Override
+    public void insertLine(int index, String line, boolean update) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line, boolean update) {
+        this.lines.add(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(String line) {
+        this.lines.add(new HoloLine(line, this));
+    }
+
+    @Override
+    public void addLine(String line, boolean update) {
+        this.lines.add(new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(IHoloLine line, boolean update) {
+        this.lines.remove(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(int index, boolean update) {
+        this.lines.remove(index);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void clearLines(boolean update) {
+        this.lines.clear();
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setGap(double gap) {
+        this.gap = gap;
+        this.update();
+    }
+
+    @Override
+    public void setGap(double gap, boolean update) {
+        this.gap = gap;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public double getGap() {
+        return this.gap;
+    }
+
+    @Override
+    public void remove() {
+        for (IHoloLine line : this.lines) line.remove();
+        lines.clear();
+    }
+}

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -678,7 +678,7 @@ public final class v1_21_R5 extends VersionSupport {
 
     @Override
     public int getVersion() {
-        return 13;
+        return 14;
     }
 
     @Override

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -731,24 +731,25 @@ public final class v1_21_R5 extends VersionSupport {
     public Block placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
         Block block = b.getRelative(x, y, z);  //ladder block
         block.setType(Material.LADDER);
-        Ladder ladder = (Ladder) block.getBlockData();
-        a.addPlacedBlock(block);
-        switch (ladderData) {
-            case 2 -> {
-                ladder.setFacing(BlockFace.NORTH);
-                block.setBlockData(ladder);
-            }
-            case 3 -> {
-                ladder.setFacing(BlockFace.SOUTH);
-                block.setBlockData(ladder);
-            }
-            case 4 -> {
-                ladder.setFacing(BlockFace.WEST);
-                block.setBlockData(ladder);
-            }
-            case 5 -> {
-                ladder.setFacing(BlockFace.EAST);
-                block.setBlockData(ladder);
+        if(block.getBlockData() instanceof Ladder ladder) {
+            a.addPlacedBlock(block);
+            switch (ladderData) {
+                case 2 -> {
+                    ladder.setFacing(BlockFace.NORTH);
+                    block.setBlockData(ladder);
+                }
+                case 3 -> {
+                    ladder.setFacing(BlockFace.SOUTH);
+                    block.setBlockData(ladder);
+                }
+                case 4 -> {
+                    ladder.setFacing(BlockFace.WEST);
+                    block.setBlockData(ladder);
+                }
+                case 5 -> {
+                    ladder.setFacing(BlockFace.EAST);
+                    block.setBlockData(ladder);
+                }
             }
         }
         return b;

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -1,0 +1,906 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R5;
+
+import com.mojang.datafixers.util.Pair;
+import com.saicone.rtag.RtagItem;
+import com.saicone.rtag.util.OptionalType;
+import com.saicone.rtag.util.SkullTexture;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.arena.team.TeamColor;
+import com.tomkeuper.bedwars.api.entity.Despawnable;
+import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
+import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import com.tomkeuper.bedwars.support.version.common.VersionCommon;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable.DespawnableAttributes;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable.DespawnableFactory;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.despawnable.DespawnableType;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.hologram.HoloLine;
+import com.tomkeuper.bedwars.support.version.v1_21_R5.hologram.Hologram;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.core.particles.ParticleParamRedstone;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.EntityReference;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.entity.item.EntityTNTPrimed;
+import net.minecraft.world.entity.projectile.IProjectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBase;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Ladder;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.v1_21_R5.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R5.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R5.entity.*;
+import org.bukkit.craftbukkit.v1_21_R5.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R5.util.CraftMagicNumbers;
+import org.bukkit.entity.*;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+
+import static com.tomkeuper.bedwars.api.language.Language.getList;
+
+public final class v1_21_R5 extends VersionSupport {
+
+    private final DespawnableFactory despawnableFactory;
+
+    public v1_21_R5(Plugin plugin, String name) {
+        super(plugin, name);
+        loadDefaultEffects();
+        this.despawnableFactory = new DespawnableFactory(this);
+    }
+
+    @Override
+    public void registerCommand(String name, Command cmd) {
+        ((CraftServer) getPlugin().getServer()).getCommandMap().register(name, cmd);
+    }
+
+    @Override
+    public void sendTitle(Player p, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
+    }
+
+    @Override
+    public void playAction(Player p, String text) {
+        p.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.translateAlternateColorCodes('&', text)
+                )
+        );
+    }
+
+    @Override
+    public boolean isBukkitCommandRegistered(String name) {
+        return ((CraftServer) getPlugin().getServer()).getCommandMap().getCommand(name) != null;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemInHand(@NotNull Player p) {
+        return p.getInventory().getItemInMainHand();
+    }
+
+    @Override
+    public void hideEntity(Entity e, Player p) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(e.getEntityId());
+        sendPacket(p, packet);
+    }
+
+    @Override
+    public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return Tag.ITEMS_HEAD_ARMOR.isTagged(itemStack.getType()) || Tag.ITEMS_CHEST_ARMOR.isTagged(itemStack.getType())
+                || Tag.ITEMS_LEG_ARMOR.isTagged(itemStack.getType()) || Tag.ITEMS_FOOT_ARMOR.isTagged(itemStack.getType()) || itemStack.getType() == materialElytra();
+    }
+
+    @Override
+    public boolean isTool(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return Tag.ITEMS_WOODEN_TOOL_MATERIALS.isTagged(itemStack.getType()) || Tag.ITEMS_IRON_TOOL_MATERIALS.isTagged(itemStack.getType())
+                || Tag.ITEMS_GOLD_TOOL_MATERIALS.isTagged(itemStack.getType()) || Tag.ITEMS_DIAMOND_TOOL_MATERIALS.isTagged(itemStack.getType())
+                || Tag.ITEMS_STONE_TOOL_MATERIALS.isTagged(itemStack.getType()) || Tag.ITEMS_NETHERITE_TOOL_MATERIALS.isTagged(itemStack.getType());
+    }
+
+    @Override
+    public boolean isSword(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return Tag.ITEMS_SWORDS.isTagged(itemStack.getType());
+    }
+
+    @Override
+    public boolean isAxe(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemAxe;
+    }
+
+    @Override
+    public boolean isBow(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemBow;
+    }
+
+
+    @Override
+    public boolean isProjectile(org.bukkit.inventory.ItemStack itemStack) {
+        var entity = getEntity(itemStack);
+        if (null == entity) return false;
+        return entity instanceof IProjectile;
+    }
+
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.@NotNull ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
+    public void registerEntities() {
+
+    }
+
+    @Override
+    public void spawnShop(Location loc, String name1, List<Player> players, IArena arena) {
+        Location l = loc.clone();
+
+        if (l.getWorld() == null) return;
+        Villager vlg = (Villager) l.getWorld().spawnEntity(loc, EntityType.VILLAGER);
+        vlg.setAI(false);
+        vlg.setRemoveWhenFarAway(false);
+        vlg.setCollidable(false);
+        vlg.setInvulnerable(true);
+        vlg.setSilent(true);
+    }
+
+    @Override
+    public void spawnShopHologram(Location loc, String name1, List<Player> players, IArena arena, ITeam team) {
+        for (Player p : players) {
+            String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
+            IHologram h = createHologram(p, loc, nume);
+
+            new ShopHolo(h, loc, arena, team);
+        }
+
+        for (Player p : players) {
+            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+        }
+    }
+
+    @Override
+    public double getDamage(org.bukkit.inventory.ItemStack i) {
+        var tag = getTag(i);
+        if (null == tag) {
+            throw new RuntimeException("Provided item has no Tag");
+        }
+        return tag.b("generic.attackDamage", 0);
+    }
+
+    @Override
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+        var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH
+        );
+    }
+
+    @Override
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+        var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM
+        );
+    }
+
+    @Override
+    public void minusAmount(Player p, org.bukkit.inventory.@NotNull ItemStack i, int amount) {
+        if (i.getAmount() - amount <= 0) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
+            return;
+        }
+        i.setAmount(i.getAmount() - amount);
+        //noinspection UnstableApiUsage
+        p.updateInventory();
+    }
+
+    @Override
+    public void setSource(TNTPrimed tnt, Player owner) {
+        EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
+        EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
+        nmsTNT.j = nmsEntityLiving != null ? new EntityReference(nmsEntityLiving) : null;
+    }
+
+    @Override
+    public void voidKill(Player p) {
+        p.damage(1000.0);
+    }
+
+    @Override
+    public void hideArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public void showArmor(Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(victim.getInventory().getHelmet())));
+        items.add(new Pair<>(EnumItemSlot.e, CraftItemStack.asNMSCopy(victim.getInventory().getChestplate())));
+        items.add(new Pair<>(EnumItemSlot.d, CraftItemStack.asNMSCopy(victim.getInventory().getLeggings())));
+        items.add(new Pair<>(EnumItemSlot.c, CraftItemStack.asNMSCopy(victim.getInventory().getBoots())));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public EnderDragon spawnDragon(Location l, ITeam team) {
+        if (l == null || l.getWorld() == null) {
+            getPlugin().getLogger().log(Level.WARNING, "Could not spawn Dragon. Location is null");
+            return null;
+        }
+        EnderDragon ed = (EnderDragon) l.getWorld().spawnEntity(l, EntityType.ENDER_DRAGON);
+        ed.setPhase(EnderDragon.Phase.CIRCLING);
+        return ed;
+    }
+
+    @Override
+    public void colorBed(ITeam bwt) {
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
+                if (bed instanceof Bed) {
+                    bed.setType(bwt.getColor().bedMaterial());
+                    bed.update();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
+        try {
+            // blast resistance
+            Field field = BlockBase.class.getDeclaredField("explosionResistance");
+            field.setAccessible(true);
+            // end stone
+            field.set(Blocks.fY, endStoneBlast);
+            // obsidian
+            field.set(Blocks.cy, glassBlast);
+            // standard glass
+            field.set(Blocks.aX, glassBlast);
+
+            var coloredGlass = new net.minecraft.world.level.block.Block[]{
+                    Blocks.ez, Blocks.eA, Blocks.eB, Blocks.eC,
+                    Blocks.eD, Blocks.eE, Blocks.eF, Blocks.eG,
+                    Blocks.eH, Blocks.eI, Blocks.eJ, Blocks.eK,
+                    Blocks.eL, Blocks.eM, Blocks.eN, Blocks.eO,
+
+                    Blocks.aX,
+            };
+
+            Arrays.stream(coloredGlass).forEach(
+                    glass -> {
+                        try {
+                            field.set(glass, glassBlast);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            //noinspection CallToPrintStackTrace
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public float getBlastResistance(org.bukkit.block.Block bukkitBlock) {
+        try {
+            // Convert Bukkit block to NMS Block
+            net.minecraft.world.level.block.Block nmsBlock = CraftMagicNumbers.getBlock(bukkitBlock.getType());
+
+            // Access the 'durability' field
+            Field durabilityField = BlockBase.class.getDeclaredField("explosionResistance");
+            durabilityField.setAccessible(true);
+
+            return durabilityField.getFloat(nmsBlock);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 0; // Default if something fails
+    }
+
+    @Override
+    public void setBlockTeamColor(Block block, TeamColor teamColor) {
+        if (block.getType().toString().contains("STAINED_GLASS") || block.getType().toString().equals("GLASS")) {
+            block.setType(teamColor.glassMaterial());
+        } else if (block.getType().toString().contains("_TERRACOTTA")) {
+            block.setType(teamColor.glazedTerracottaMaterial());
+        } else if (block.getType().toString().contains("_WOOL")) {
+            block.setType(teamColor.woolMaterial());
+        }
+    }
+
+    @Override
+    public void setCollide(Player p, IArena a, boolean value) {
+        p.setCollidable(value);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addCustomData(org.bukkit.inventory.ItemStack i, String data) {
+        return RtagItem.edit(i, tag -> {
+            tag.set(data, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        });
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {
+        return RtagItem.edit(itemStack, tag -> {
+            tag.set(value, key);
+        });
+    }
+
+    @Override
+    public String getTag(org.bukkit.inventory.ItemStack itemStack, String key) {
+        var tag = getTag(itemStack);
+        return tag == null ? null : tag.b(key) ? tag.b(key, null) : null;
+    }
+
+    @Override
+    public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        if (i == null) return false;
+        if (i.getType() == org.bukkit.Material.AIR) return false;
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return tag.isNotEmpty();
+    }
+
+    @Override
+    public String getCustomData(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return (tag.isEmpty() || tag.isNotInstance(String.class)) ? null : tag.asString(null);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack colourItem(org.bukkit.inventory.ItemStack itemStack, ITeam bedWarsTeam) {
+        if (itemStack == null) return null;
+        String type = itemStack.getType().toString();
+        if (isBed(itemStack.getType())) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().bedMaterial(), itemStack.getAmount());
+        } else if (type.contains("_STAINED_GLASS_PANE")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassPaneMaterial(), itemStack.getAmount());
+        } else if (type.contains("STAINED_GLASS") || type.equals("GLASS")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassMaterial(), itemStack.getAmount());
+        } else if (type.contains("_TERRACOTTA")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glazedTerracottaMaterial(), itemStack.getAmount());
+        } else if (type.contains("_WOOL")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().woolMaterial(), itemStack.getAmount());
+        }
+        return itemStack;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack createItemStack(String material, int amount, short data) {
+        org.bukkit.inventory.ItemStack i;
+        try {
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.valueOf(material), amount);
+        } catch (Exception ex) {
+            getPlugin().getLogger().log(Level.WARNING, material + " is not a valid " + getName() + " material!");
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.BEDROCK);
+        }
+        return i;
+    }
+
+    @Override
+    public Material materialFireball() {
+        return org.bukkit.Material.FIRE_CHARGE;
+    }
+
+    @Override
+    public org.bukkit.Material materialPlayerHead() {
+        return org.bukkit.Material.PLAYER_HEAD;
+    }
+
+    @Override
+    public org.bukkit.Material materialSnowball() {
+        return org.bukkit.Material.SNOWBALL;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenHelmet() {
+        return org.bukkit.Material.GOLDEN_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenChestPlate() {
+        return org.bukkit.Material.GOLDEN_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenLeggings() {
+        return org.bukkit.Material.GOLDEN_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteHelmet() {
+        return Material.NETHERITE_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteChestPlate() {
+        return Material.NETHERITE_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteLeggings() {
+        return Material.NETHERITE_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialElytra() {
+        return Material.ELYTRA;
+    }
+
+    @Override
+    public org.bukkit.Material materialCake() {
+        return org.bukkit.Material.CAKE;
+    }
+
+    @Override
+    public org.bukkit.Material materialCraftingTable() {
+        return org.bukkit.Material.CRAFTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEnchantingTable() {
+        return org.bukkit.Material.ENCHANTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEndStone() {
+        return Material.END_STONE;
+    }
+
+    @Override
+    public org.bukkit.Material woolMaterial() {
+        return org.bukkit.Material.WHITE_WOOL;
+    }
+
+    @Override
+    public void setJoinSignBackground(BlockState b, Material material) {
+        if (b.getBlockData() instanceof WallSign) {
+            b.getBlock().getRelative(((WallSign) b.getBlockData()).getFacing().getOppositeFace()).setType(material);
+        }
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack redGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.RED_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack greenGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.LIME_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public String getShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem item = new RtagItem(itemStack);
+        OptionalType tag = item.getOptional(VersionSupport.PLUGIN_TAG_TIER_KEY);
+        return tag.isEmpty() ? "null" : tag.asString("null");
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack, String identifier) {
+        RtagItem item = new RtagItem(itemStack);
+        item.set(identifier, VersionSupport.PLUGIN_TAG_TIER_KEY);
+        item.load();
+        return item.getItem();
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getPlayerHead(Player player, org.bukkit.inventory.ItemStack copyTagFrom) {
+        org.bukkit.inventory.ItemStack head = SkullTexture.getTexturedHead(player.getUniqueId().toString());
+
+        if (copyTagFrom != null) {
+            var tag = getTag(copyTagFrom);
+            RtagItem rtagItem = new RtagItem(head);
+            rtagItem.set(tag, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+            rtagItem.load();
+            head = rtagItem.getItem();
+        }
+
+        return head;
+    }
+
+    @Override
+    public void sendPlayerSpawnPackets(Player respawned, IArena arena) {
+        if (respawned == null) return;
+        if (arena == null) return;
+        if (!arena.isPlayer(respawned)) return;
+
+        // if method was used when the player was still in re-spawning screen
+        if (arena.getRespawnSessions().containsKey(respawned)) return;
+
+        EntityPlayer entityPlayer = getPlayer(respawned);
+        PacketPlayOutSpawnEntity show = newPacketPlayOutSpawnEntity(entityPlayer);
+        PacketPlayOutEntityVelocity playerVelocity = new PacketPlayOutEntityVelocity(entityPlayer);
+        // we send head rotation packet because sometimes on respawn others see him with bad rotation
+        PacketPlayOutEntityHeadRotation head = new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()));
+
+        // retrieve current armor and in-hand items
+        // we send a packet later for timing issues where other players do not see them
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = getPlayerEquipment(entityPlayer);
+
+
+        for (Player p : arena.getPlayers()) {
+            if (p == null) continue;
+            if (p.equals(respawned)) continue;
+            // if p is in re-spawning screen continue
+            if (arena.getRespawnSessions().containsKey(p)) continue;
+
+            EntityPlayer boundTo = getPlayer(p);
+            if (p.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(p.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to regular players
+                    sendPackets(
+                            p, show, head, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list)
+                    );
+
+                    // send nearby players to respawned player
+                    // if the player has invisibility hide armor
+                    if (p.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                        hideArmor(p, respawned);
+                    } else {
+                        PacketPlayOutSpawnEntity show2 = newPacketPlayOutSpawnEntity(boundTo);
+
+                        PacketPlayOutEntityVelocity playerVelocity2 = new PacketPlayOutEntityVelocity(boundTo);
+                        PacketPlayOutEntityHeadRotation head2 = new PacketPlayOutEntityHeadRotation(boundTo, getCompressedAngle(boundTo.getBukkitYaw()));
+                        sendPackets(respawned, show2, playerVelocity2, head2);
+                        showArmor(p, respawned);
+                    }
+                }
+            }
+        }
+
+        for (Player spectator : arena.getSpectators()) {
+            if (spectator == null) continue;
+            if (spectator.equals(respawned)) continue;
+            respawned.hidePlayer(getPlugin(), spectator);
+            if (spectator.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(spectator.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to spectator
+                    sendPackets(
+                            spectator, show, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list),
+                            new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()))
+                    );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getInventoryName(@NotNull InventoryEvent e) {
+        return e.getView().getTitle();
+    }
+
+    @Override
+    public void setUnbreakable(ItemMeta itemMeta) {
+        itemMeta.setUnbreakable(true);
+    }
+
+    @Override
+    public int getVersion() {
+        return 13;
+    }
+
+    @Override
+    public void registerVersionListeners() {
+        new VersionCommon(this);
+    }
+
+    @Override
+    public String getMainLevel() {
+        //noinspection deprecation
+        return ((DedicatedServer) MinecraftServer.getServer()).a().l;
+    }
+
+    @Override
+    public Fireball setFireballDirection(Fireball fireball, Vector vector) {
+        fireball.setDirection(vector);
+        return fireball;
+    }
+
+    @Override
+    public void playRedStoneDot(Player player) {
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                ParticleParamRedstone.b,
+                true,
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player p : player.getWorld().getPlayers()) {
+            if (p.equals(player)) continue;
+            sendPacket(p, particlePacket);
+        }
+    }
+
+    @Override
+    public void clearArrowsFromPlayerBody(Player player) {
+        // minecraft clears them on death on newer version
+    }
+
+    @Override
+    public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
+        b.getRelative(x, y, z).setType(color.woolMaterial());
+        a.addPlacedBlock(b.getRelative(x, y, z));
+        return b.getRelative(x, y, z);
+    }
+
+    @Override
+    public Block placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
+        Block block = b.getRelative(x, y, z);  //ladder block
+        block.setType(Material.LADDER);
+        Ladder ladder = (Ladder) block.getBlockData();
+        a.addPlacedBlock(block);
+        switch (ladderData) {
+            case 2 -> {
+                ladder.setFacing(BlockFace.NORTH);
+                block.setBlockData(ladder);
+            }
+            case 3 -> {
+                ladder.setFacing(BlockFace.SOUTH);
+                block.setBlockData(ladder);
+            }
+            case 4 -> {
+                ladder.setFacing(BlockFace.WEST);
+                block.setBlockData(ladder);
+            }
+            case 5 -> {
+                ladder.setFacing(BlockFace.EAST);
+                block.setBlockData(ladder);
+            }
+        }
+        return b;
+    }
+
+    @Override
+    public void playVillagerEffect(Player player, Location location) {
+        player.spawnParticle(Particle.HAPPY_VILLAGER, location, 1);
+    }
+
+    @Override
+    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, location, linesList);
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, linesList, location);
+    }
+
+    @Override
+    public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
+        return new HoloLine(text, hologram);
+    }
+
+    @Override
+    public IGeneratorAnimation createDefaultGeneratorAnimation(ArmorStand armorStand) {
+        return new DefaultGenAnimation(armorStand);
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
+        for (Player p : armorStand.getWorld().getPlayers()) {
+            sendPacket(p, destroy);
+        }
+    }
+
+    @Override
+    public ArmorStand createPacketArmorStand(Location loc) {
+        if (loc.getWorld() == null) {
+            throw new RuntimeException("World of a location should not be null.");
+        }
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+
+        for (Player p : loc.getWorld().getPlayers()) {
+            sendPacket(p, spawn);
+        }
+        return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);
+    }
+
+    public static void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().g.b(packet);
+    }
+
+    public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().g;
+        for (Packet<?> p : packets) {
+            connection.b(p);
+        }
+    }
+
+    /**
+     * Gets the NMS Item from ItemStack
+     */
+    private @Nullable Item getItem(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.h();
+    }
+
+    /**
+     * Gets the NMS Entity from ItemStack
+     */
+    private @Nullable net.minecraft.world.entity.Entity getEntity(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.I();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem rtagItem = new RtagItem(itemStack);
+        return (NBTTagCompound) rtagItem.getTag();
+    }
+
+    public EntityPlayer getPlayer(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    public List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> getPlayerEquipment(@NotNull EntityPlayer entityPlayer) {
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = new ArrayList<>();
+        list.add(new Pair<>(EnumItemSlot.a, entityPlayer.a(EnumItemSlot.a)));
+        list.add(new Pair<>(EnumItemSlot.b, entityPlayer.a(EnumItemSlot.b)));
+        list.add(new Pair<>(EnumItemSlot.f, entityPlayer.a(EnumItemSlot.f)));
+        list.add(new Pair<>(EnumItemSlot.e, entityPlayer.a(EnumItemSlot.e)));
+        list.add(new Pair<>(EnumItemSlot.d, entityPlayer.a(EnumItemSlot.d)));
+        list.add(new Pair<>(EnumItemSlot.c, entityPlayer.a(EnumItemSlot.c)));
+
+        return list;
+    }
+
+    public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
+        return new PacketPlayOutSpawnEntity(
+                nmsEntity.hashCode(),
+                nmsEntity.cK(),
+                nmsEntity.dC(),
+                nmsEntity.dE(),
+                nmsEntity.dI(),
+                nmsEntity.dR(),
+                nmsEntity.getBukkitYaw(),
+                nmsEntity.ap(),
+                0,
+                nmsEntity.dA(),
+                nmsEntity.cE()
+        );
+    }
+}


### PR DESCRIPTION
com.saicone.rtag:rtag:1.5.11
v1_21_R5
FireballListener: Catch IllegalArgumentException (probably needs better fix)



## ✅ Admission Tests

### Regular
- [x] Cannot drop default wooden sword
- [x] Cannot break own bed
- [x] Cannot remove armor
- [x] Can break player-placed blocks
- [x] Cannot place blocks in team-spawn region
- [x] Cannot damage shopkeepers
- [x] Shopkeepers immune to Silverfishes/Iron Golems
- [x] Cannot be targeted by own Silverfishes/Iron Golems
- [x] Shopkeepers immune to Explosions

### Console
- [x] No errors when placing TNT
- [x] No errors when respawning players
- [x] No errors on server startup
- [x] No errors during regular match

### Visual
- [x] TNT Spoil shows RED particles above head
- [x] Team upgrades announced in chat
- [x] Invisible to others during respawn phase

### Blast Protection
- [x] Regular Glass is blast-resistant
- [x] Colored Glass is blast-resistant
- [x] Obsidian is blast-resistant
- [x] Endstone (Fireball) resists blasts
- [x] Wool covered with Glass or Stained Glass does not explode

---

## 🛠️ NMS Update Checklist

- [ ] Previously inaccessible fields now accessible? (reflective → direct access)
---
