### PR TITLE
eggbridge & fireball update

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -263,6 +263,7 @@ public class ConfigPath {
     public static final String GENERAL_FIREBALL_DAMAGE_SELF = GENERAL_FIREBALL_DAMAGE_PATH + ".self";
     public static final String GENERAL_FIREBALL_DAMAGE_ENEMY = GENERAL_FIREBALL_DAMAGE_PATH + ".enemy";
     public static final String GENERAL_FIREBALL_DAMAGE_TEAMMATES = GENERAL_FIREBALL_DAMAGE_PATH + ".teammates";
+    public static final String GENERAL_FIREBALL_EXPLOSION_PROOF_BLOCKS = GENERAL_FIREBALL_PATH + ".explosion-proof-blocks";
 
     public static final String GENERAL_EGGBRIDGE = "eggbridge-settings";
     public static final String GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER = GENERAL_EGGBRIDGE+".distance-from-player-to-start-building";

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -253,15 +253,25 @@ public class ConfigPath {
     public static final String GENERAL_FIREBALL_EXPLOSION_SIZE = GENERAL_FIREBALL_PATH + ".explosion-size";
     public static final String GENERAL_FIREBALL_SPEED_MULTIPLIER = GENERAL_FIREBALL_PATH + ".speed-multiplier";
     public static final String GENERAL_FIREBALL_MAKE_FIRE = GENERAL_FIREBALL_PATH + ".make-fire";
-    private static final String GENERAL_FIREBALL_KNOCKBACK_PATH = GENERAL_FIREBALL_PATH + ".knockback";
-    public static final String GENERAL_FIREBALL_KNOCKBACK_VERTICAL = GENERAL_FIREBALL_KNOCKBACK_PATH + ".vertical";
-    public static final String GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL = GENERAL_FIREBALL_KNOCKBACK_PATH + ".horizontal";
+    public static final String GENERAL_FIREBALL_KNOCKBACK_VERTICAL_SELF = GENERAL_FIREBALL_PATH + ".knockback.vertical.self";
+    public static final String GENERAL_FIREBALL_KNOCKBACK_VERTICAL_OTHERS = GENERAL_FIREBALL_PATH + ".knockback.vertical.others";
+    public static final String GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_SELF = GENERAL_FIREBALL_PATH + ".knockback.horizontal.self";
+    public static final String GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_OTHERS = GENERAL_FIREBALL_PATH + ".knockback.horizontal.others";
+    public static final String GENERAL_FIREBALL_JUMP_TOLERANCE = GENERAL_FIREBALL_PATH + ".jump-tolerance";
     public static final String GENERAL_FIREBALL_COOLDOWN = GENERAL_FIREBALL_PATH + ".cooldown";
     private static final String GENERAL_FIREBALL_DAMAGE_PATH = GENERAL_FIREBALL_PATH + ".damage";
     public static final String GENERAL_FIREBALL_DAMAGE_SELF = GENERAL_FIREBALL_DAMAGE_PATH + ".self";
     public static final String GENERAL_FIREBALL_DAMAGE_ENEMY = GENERAL_FIREBALL_DAMAGE_PATH + ".enemy";
     public static final String GENERAL_FIREBALL_DAMAGE_TEAMMATES = GENERAL_FIREBALL_DAMAGE_PATH + ".teammates";
 
+    public static final String GENERAL_EGGBRIDGE = "eggbridge-settings";
+    public static final String GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER = GENERAL_EGGBRIDGE+".distance-from-player-to-start-building";
+    public static final String GENERAL_EGGBRIDGE_MAX_LENGTH = GENERAL_EGGBRIDGE+".max-length";
+    public static final String GENERAL_EGGBRIDGE_MAX_HEIGHT = GENERAL_EGGBRIDGE+".max-height";
+    public static final String GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT = GENERAL_EGGBRIDGE+".when-used-close-to-build-limit";
+    public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-build-limit";
+    public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".send-warn-message";
+    public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".cancel-usage";
 
     public static final String GENERAL_CONFIGURATION_DATABASE_PATH = "database";
     public static final String GENERAL_CONFIGURATION_DATABASE_TYPE = GENERAL_CONFIGURATION_DATABASE_PATH + ".type";

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/language/Messages.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/language/Messages.java
@@ -282,6 +282,9 @@ public class Messages {
     public static String INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN = "interact-invisibility-removed-damaged";
     public static String INTERACT_MAGIC_MILK_REMOVED = "interact-magic-milk-removed";
 
+    /** Eggbridge related */
+    public static String EGGBRIDGE_BUILD_LIMIT_WARNING = "eggbridge-build-limit-warning";
+
     /** PvP related */
     public static String PLAYER_DIE_RESPAWN_TITLE = "player-respawn-title";
     public static String PLAYER_DIE_RESPAWN_SUBTITLE = "player-respawn-subtitle";

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/EggBridgeTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/EggBridgeTask.java
@@ -37,6 +37,8 @@ import org.bukkit.entity.Egg;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
+import static com.tomkeuper.bedwars.BedWars.config;
+
 @SuppressWarnings("WeakerAccess")
 public class EggBridgeTask implements Runnable {
 
@@ -82,13 +84,13 @@ public class EggBridgeTask implements Runnable {
 
         if (getProjectile().isDead()
                 || !arena.isPlayer(getPlayer())
-                || getPlayer().getLocation().distance(getProjectile().getLocation()) > 27
-                || getPlayer().getLocation().getY() - getProjectile().getLocation().getY() > 9) {
+                || getPlayer().getLocation().distance(getProjectile().getLocation()) > config.getInt(ConfigPath.GENERAL_EGGBRIDGE_MAX_LENGTH)
+                || getPlayer().getLocation().getY() - getProjectile().getLocation().getY() > config.getInt(ConfigPath.GENERAL_EGGBRIDGE_MAX_HEIGHT)) {
             EggBridge.removeEgg(projectile);
             return;
         }
 
-        if (getPlayer().getLocation().distance(loc) > 4.0D) {
+        if (getPlayer().getLocation().distance(loc) > config.getDouble(ConfigPath.GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER)) {
 
             Block b2 = loc.clone().subtract(0.0D, 2.0D, 0.0D).getBlock();
             if (!Misc.isBuildProtected(b2.getLocation(), getArena())) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -142,6 +142,7 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_SELF, 2.0);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_ENEMY, 2.0);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_TEAMMATES, 0.0);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_PROOF_BLOCKS, Arrays.asList("END_STONE"));
 
         // eggbridge category
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER, 4.0);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -133,13 +133,23 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE, 3);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_SPEED_MULTIPLIER, 10);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_MAKE_FIRE, false);
-        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL, 1.0);
-        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL, 0.65);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_SELF, 1.0);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_OTHERS, 1.0);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL_SELF, 0.65);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL_OTHERS, 0.65);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_JUMP_TOLERANCE, 0.5);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_COOLDOWN, 0.5);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_SELF, 2.0);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_ENEMY, 2.0);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_TEAMMATES, 0.0);
-        //
+
+        // eggbridge category
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER, 4.0);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MAX_LENGTH, 27);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MAX_HEIGHT, 9);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE, 2);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER, false);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE, false);
 
         // Database Configuration
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_DATABASE_TYPE, "SQLite");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Bangla.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Bangla.java
@@ -255,6 +255,7 @@ public class Bangla extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cApni ei chest ti khulte parben na karon ei team ti eliminate hoini!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cApni ar invisible non karon apni damage niyechen!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7void e pore gelen.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7void e pore gelen. &b&lFINAL KILL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_killer_color%%bw_killer_name%&7 %bw_player_color%%bw_player% &7ke void e falalen.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/English.java
@@ -256,6 +256,7 @@ public class English extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cYou can't open this chest because this team wasn't eliminated!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7fell into the void.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7fell into the void. &b&lFINAL KILL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7was knocked into the void by %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Hindi.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Hindi.java
@@ -255,6 +255,7 @@ public class Hindi extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cAp ye chest open nahi kar sakte kyuki ye team eliminate nahi hua hai!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cAp ab invisible nahi rahe kyuku apne damage kiya hein!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7void me gire.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7void me gire. &b&lFINAL KILL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_killer_color%%bw_killer_name% %bw_player_color%%bw_player% &7ko void me gira diye.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Indonesia.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Indonesia.java
@@ -254,6 +254,7 @@ public class Indonesia extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cAnda tidak dapat membuka peti ini karena tim ini belum tereliminasi!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7jatuh ke void.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7jatuh ke void. &b&lPEMBUNUHAN TERAKHIR!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7terlempar ke dalam void oleh %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Italian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Italian.java
@@ -256,6 +256,7 @@ public class Italian extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cNon puoi aprire questa cesta, perchè il team non è stato eliminato.");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cNon sei più invisibile perchè hai preso danno!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7è caduto nel vuoto.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7è caduto nel vuoto. &b&lUCCISIONE FINALE!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7è caduto nel vuoto con l'aiuto di %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Persian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Persian.java
@@ -256,6 +256,7 @@ public class Persian extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cShoma Nemitavanid In Chest Ro Be Dalil Inke Player Haye Team Hanoz Namordan Baz Konid!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7Dakhel Void Oftad.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7Dakhel Void Oftad. &b&lFINAL KILL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7Tavasote %bw_killer_color%%bw_killer_name% &7Be Dakhel Void Part Shod.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Polish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Polish.java
@@ -251,6 +251,7 @@ public class Polish extends Language{
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cNie mozesz otworzyc skrzyni tej druzyny poniewaz zostala ona wyeliminowana!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cNie jesteś już niewidzialny, ponieważ otrzymałeś obrażenia!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7spadl do pustki.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7spadl do pustki. &b&lOSTATECZNE ZABOJSTWO!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7zostal zepchniety do pustki przez %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Portuguese.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Portuguese.java
@@ -254,6 +254,7 @@ public class Portuguese extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cVocê não pode abrir este baú porque esse time não foi eliminado!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cSua invisibilidade foi removida pois você tomou dano!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cOs efeitos do seu leite acabaram!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7caiu no void.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7caiu no void. &b&lKILL FINAL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7foi jogado no void por %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Romanian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Romanian.java
@@ -250,6 +250,7 @@ public class Romanian extends Language {
         yml.addDefault(Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT_TO_VICTIM, "&f&lPAT DISTRUS > &7Patul tau a fost distrus de %bw_player_color%%bw_player%&7!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7a cazut in void.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7a cazut in void. &b&lUCIDERE FINALA!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7a fost impins in void de %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Russian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Russian.java
@@ -182,6 +182,7 @@ public class Russian extends Language{
         yml.addDefault(Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT_TO_VICTIM, "&f&lУНИЧТОЖЕНИЕ КРОВАТИ > &7Ваша кровать разрушена игроком %bw_player_color%%bw_player%&7!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7упал.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7упал. &b&lФИНАЛЬНОЕ УБИЙСТВО!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7был скинут в бездну %bw_killer_color%%bw_killer_name%&7.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/SimplifiedChinese.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/SimplifiedChinese.java
@@ -255,6 +255,7 @@ public class SimplifiedChinese extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&c此队伍还未被团灭，因此你不能打开该团队箱子！");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&c你因受到伤害而被迫退出隐身！");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player%&7掉进了虚空。");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player%&7掉进了虚空。 &b&l最终击杀！");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player%&7被%bw_killer_color%%bw_killer_name%&7丢进了虚空。");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Spanish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Spanish.java
@@ -185,6 +185,7 @@ public class Spanish extends Language {
         yml.addDefault(Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT_TO_VICTIM, "&f&lCAMA DESTRUIDA > &7Tu cama ha sido destruida por %bw_player_color%%bw_player%&7!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYa no eres invisible porque has recibido daño!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.TEAM_ELIMINATED_CHAT, "\n&f&lEQUIPO ELIMINADO > El equipo %bw_team_color%%bw_team_name% &cha sido eliminado\n");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7ha caído al vacio.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7ha caído al vacio. &b&lMUERTE FINAL!");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Turkish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Turkish.java
@@ -256,6 +256,7 @@ public class Turkish extends Language {
         yml.addDefault(Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED, "&cElenmemiş bir takımın sandığını açamazsın!");
         yml.addDefault(Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN, "&cYou are no longer invisible because you have taken damage!");
         yml.addDefault(Messages.INTERACT_MAGIC_MILK_REMOVED, "&cYour Magic Milk wore off!");
+        yml.addDefault(Messages.EGGBRIDGE_BUILD_LIMIT_WARNING, "&cYou are too close to the build limit!");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_REGULAR_KILL, "%bw_player_color%%bw_player% &7boşluğa düştü.");
         yml.addDefault(Messages.PLAYER_DIE_VOID_FALL_FINAL_KILL, "%bw_player_color%%bw_player% &7boşluğa düştü. &b&lFINAL KILL!");
         yml.addDefault(Messages.PLAYER_DIE_KNOCKED_IN_VOID_REGULAR_KILL, "%bw_player_color%%bw_player% &7 adlı oyuncu %bw_killer_color%%bw_killer_name%&7 tarafından boşluğa atıldı.");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
@@ -22,21 +22,29 @@ package com.tomkeuper.bedwars.listeners;
 
 import com.tomkeuper.bedwars.BedWars;
 import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.configuration.ConfigPath;
 import com.tomkeuper.bedwars.api.events.gameplay.EggBridgeThrowEvent;
 import com.tomkeuper.bedwars.api.server.ServerType;
 import com.tomkeuper.bedwars.arena.Arena;
 import com.tomkeuper.bedwars.arena.tasks.EggBridgeTask;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.entity.Egg;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.tomkeuper.bedwars.BedWars.config;
 
 @SuppressWarnings("WeakerAccess")
 public class EggBridge implements Listener {
@@ -59,6 +67,20 @@ public class EggBridge implements Listener {
                 IArena arena = Arena.getArenaByPlayer(shooter);
                 if (arena != null) {
                     if (arena.isPlayer(shooter)) {
+                        if (shooter.getLocation().getY() > arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y) - config.getInt(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE)
+                                || shooter.getLocation().getY() < arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y) + config.getInt(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE)) {
+                            if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER)) {
+                                shooter.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cTúl közel vagy az építési limithez!"));
+                            }
+                            if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE)) {
+                                if (shooter.getGameMode() != GameMode.CREATIVE) {
+                                    shooter.getInventory().addItem(new ItemStack(Material.EGG, 1));
+                                }
+                                event.setCancelled(true);
+                                return;
+                            }
+                        }
+
                         EggBridgeThrowEvent throwEvent = new EggBridgeThrowEvent(shooter, arena);
                         Bukkit.getPluginManager().callEvent(throwEvent);
                         if (event.isCancelled()) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -53,6 +53,9 @@ import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 
 import java.util.*;
+
+import static com.tomkeuper.bedwars.BedWars.config;
+
 public class FireballListener implements Listener {
 
     private final double fireballExplosionSize, fireballHorizontalSelf, fireballHorizontalOthers, fireballVerticalSelf, fireballVerticalOthers;
@@ -168,7 +171,7 @@ public class FireballListener implements Listener {
                 if (y < 0) {
                     y += 1.5;
                 }
-                if (y <= 0.5) {
+                if (y <= config.getDouble(ConfigPath.GENERAL_FIREBALL_JUMP_TOLERANCE)) {
                     y = fireballVerticalSelf * 1.5; // kb for not jumping
                 } else {
                     y = y * fireballVerticalSelf * 1.5; // kb for jumping
@@ -179,7 +182,7 @@ public class FireballListener implements Listener {
                 if (y < 0) {
                     y += 1.5;
                 }
-                if (y <= 0.5) {
+                if (y <= config.getDouble(ConfigPath.GENERAL_FIREBALL_JUMP_TOLERANCE)) {
                     y = fireballVerticalOthers * 1.5; // kb for not jumping
                 } else {
                     y = y * fireballVerticalOthers * 1.5; // kb for jumping

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -55,7 +55,7 @@ import org.bukkit.util.Vector;
 import java.util.*;
 public class FireballListener implements Listener {
 
-    private final double fireballExplosionSize, fireballHorizontal, fireballVertical;
+    private final double fireballExplosionSize, fireballHorizontalSelf, fireballHorizontalOthers, fireballVerticalSelf, fireballVerticalOthers;
     private final double damageSelf, damageEnemy, damageTeammates;
     private final double fireballSpeedMultiplier, fireballCooldown;
     private final boolean fireballMakeFire;
@@ -64,8 +64,10 @@ public class FireballListener implements Listener {
         YamlConfiguration config = BedWars.config.getYml();
         fireballExplosionSize = config.getDouble(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE);
         fireballMakeFire = config.getBoolean(ConfigPath.GENERAL_FIREBALL_MAKE_FIRE);
-        fireballHorizontal = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL) * -1;
-        fireballVertical = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL);
+        fireballHorizontalSelf = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_SELF) * -1;
+        fireballHorizontalOthers = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_HORIZONTAL_OTHERS) * -1;
+        fireballVerticalSelf = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL_SELF);
+        fireballVerticalOthers = config.getDouble(ConfigPath.GENERAL_FIREBALL_KNOCKBACK_VERTICAL_OTHERS);
         damageSelf = config.getDouble(ConfigPath.GENERAL_FIREBALL_DAMAGE_SELF);
         damageEnemy = config.getDouble(ConfigPath.GENERAL_FIREBALL_DAMAGE_ENEMY);
         damageTeammates = config.getDouble(ConfigPath.GENERAL_FIREBALL_DAMAGE_TEAMMATES);
@@ -157,15 +159,31 @@ public class FireballListener implements Listener {
 
             Vector playerVector = player.getLocation().toVector();
             Vector normalizedVector = vector.subtract(playerVector).normalize();
-            Vector horizontalVector = normalizedVector.multiply(fireballHorizontal);
-            double y = normalizedVector.getY();
-            if (y < 0) {
-                y += 1.5;
-            }
-            if (y <= 0.5) {
-                y = fireballVertical * 1.5; // kb for not jumping
+            Vector horizontalVector;
+            double y;
+
+            if (entity.getUniqueId() == source.getUniqueId()) {
+                horizontalVector = normalizedVector.multiply(fireballHorizontalSelf);
+                y = normalizedVector.getY();
+                if (y < 0) {
+                    y += 1.5;
+                }
+                if (y <= 0.5) {
+                    y = fireballVerticalSelf * 1.5; // kb for not jumping
+                } else {
+                    y = y * fireballVerticalSelf * 1.5; // kb for jumping
+                }
             } else {
-                y = y * fireballVertical * 1.5; // kb for jumping
+                horizontalVector = normalizedVector.multiply(fireballHorizontalOthers);
+                y = normalizedVector.getY();
+                if (y < 0) {
+                    y += 1.5;
+                }
+                if (y <= 0.5) {
+                    y = fireballVerticalOthers * 1.5; // kb for not jumping
+                } else {
+                    y = y * fireballVerticalOthers * 1.5; // kb for jumping
+                }
             }
 
             try {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -34,7 +34,9 @@ import com.tomkeuper.bedwars.arena.LastHit;
 import com.tomkeuper.bedwars.arena.team.BedWarsTeam;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
@@ -42,10 +44,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.ExplosionPrimeEvent;
-import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.*;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -219,6 +218,28 @@ public class FireballListener implements Listener {
                 }
             }
         }
+    }
+
+    @EventHandler
+    public void onFireballExplode(EntityExplodeEvent event) {
+        if (!(event.getEntity() instanceof Fireball)) {
+            return;
+        }
+
+        ProjectileSource projectileSource = ((Fireball) event.getEntity()).getShooter();
+        if (!(projectileSource instanceof Player)) {
+            return;
+        }
+
+        Player source = (Player) projectileSource;
+        IArena arena = Arena.getArenaByPlayer(source);
+
+        if (arena == null || arena.getStatus() != GameState.playing) {
+            return;
+        }
+
+        List<String> explosionProofMaterials = config.getList(ConfigPath.GENERAL_FIREBALL_EXPLOSION_PROOF_BLOCKS);
+        event.blockList().removeIf(block -> explosionProofMaterials.contains(block.getType().toString()));
     }
 
     private void damagePlayer(Player player, double damageTeammates) {


### PR DESCRIPTION
Hello! I've added the following for the fireball:
- config options for the knockback of the fireball for the player itself and other players too. (before both the player and others got the same knockback - it was bad for the fireball jumps and using fireballs for attacking)
- config option for the jump tolerance of the fireball (So it can be set lower to count worse fireball jumps as correct jumping)
<img width="148" height="175" alt="image" src="https://github.com/user-attachments/assets/cf72c5b1-be0c-484e-bca1-63eff07779d6" />

And these for the eggbridge:
- config section for the eggbridge, because it was bad that we can't change anything about it.
- can be configured: max length, min distance from the player to start building, max height and a build limit warning system:
- the system is fully optional, and off by default, and it's point is to warn players and also cancel the eggbridge usage close to the build limits. So they don't experience "throwing the egg and nothing happens".
- the warning message is in all the lang files, and can be customized.
<img width="343" height="177" alt="image" src="https://github.com/user-attachments/assets/ed66fedb-c7cc-4db5-ac6d-57671e188b7d" />

Hope this is a useful pull request, and feel free to ask me if you have any questions.
Have a nice day :)
