### PR TITLE
Eggbridge update

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -270,8 +270,8 @@ public class ConfigPath {
     public static final String GENERAL_EGGBRIDGE_MAX_LENGTH = GENERAL_EGGBRIDGE+".max-length";
     public static final String GENERAL_EGGBRIDGE_MAX_HEIGHT = GENERAL_EGGBRIDGE+".max-height";
     public static final String GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT = GENERAL_EGGBRIDGE+".when-used-close-to-build-limit";
-    public static final String GENERAL_EGGBRIDGE_MAX_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-max-build-limit";
-    public static final String GENERAL_EGGBRIDGE_MIN_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-min-build-limit";
+    public static final String GENERAL_EGGBRIDGE_MAX_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".distance-to-max-build-limit";
+    public static final String GENERAL_EGGBRIDGE_MIN_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".distance-to-min-build-limit";
     public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".send-warn-message";
     public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".cancel-usage";
 

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -304,20 +304,24 @@ public class ConfigPath {
     public static final String SHOP_SPECIAL_TOWER_ENABLE = SHOP_SPECIALS_PATH + ".tower.enable";
     public static final String SHOP_SPECIAL_TOWER_MATERIAL = SHOP_SPECIALS_PATH + ".tower.material";
     public static final String SHOP_SPECIAL_SILVERFISH_ENABLE = SHOP_SPECIALS_PATH + ".silverfish.enable";
+    public static final String SHOP_SPECIAL_SILVERFISH_REMOVES_INVISIBILITY = SHOP_SPECIALS_PATH + ".silverfish.remove-invisibility-on-attack";
     public static final String SHOP_SPECIAL_SILVERFISH_MATERIAL = SHOP_SPECIALS_PATH + ".silverfish.material";
     public static final String SHOP_SPECIAL_SILVERFISH_DATA = SHOP_SPECIALS_PATH + ".silverfish.data";
     public static final String SHOP_SPECIAL_SILVERFISH_HEALTH = SHOP_SPECIALS_PATH + ".silverfish.health";
     public static final String SHOP_SPECIAL_SILVERFISH_DAMAGE = SHOP_SPECIALS_PATH + ".silverfish.damage";
     public static final String SHOP_SPECIAL_SILVERFISH_SPEED = SHOP_SPECIALS_PATH + ".silverfish.speed";
     public static final String SHOP_SPECIAL_SILVERFISH_DESPAWN = SHOP_SPECIALS_PATH + ".silverfish.despawn";
+    public static final String SHOP_SPECIAL_SILVERFISH_PATH_FINDING_TICKS = SHOP_SPECIALS_PATH + ".silverfish.path-finding-ticks";
 
 
     public static final String SHOP_SPECIAL_IRON_GOLEM_ENABLE = SHOP_SPECIALS_PATH + ".iron-golem.enable";
+    public static final String SHOP_SPECIAL_IRON_GOLEM_REMOVES_INVISIBILITY = SHOP_SPECIALS_PATH + ".iron-golem.remove-invisibility-on-attack";
     public static final String SHOP_SPECIAL_IRON_GOLEM_MATERIAL = SHOP_SPECIALS_PATH + ".iron-golem.material";
     public static final String SHOP_SPECIAL_IRON_GOLEM_DATA = SHOP_SPECIALS_PATH + ".iron-golem.data";
     public static final String SHOP_SPECIAL_IRON_GOLEM_HEALTH = SHOP_SPECIALS_PATH + ".iron-golem.health";
     public static final String SHOP_SPECIAL_IRON_GOLEM_DESPAWN = SHOP_SPECIALS_PATH + ".iron-golem.despawn";
     public static final String SHOP_SPECIAL_IRON_GOLEM_SPEED = SHOP_SPECIALS_PATH + ".iron-golem.speed";
+    public static final String SHOP_SPECIAL_IRON_GOLEM_PATH_FINDING_TICKS = SHOP_SPECIALS_PATH + ".iron-golem.path-finding-ticks";
 
     public static final String SHOP_SETTINGS_QUICK_BUY_CATEGORY_PATH = SHOP_SETTINGS_PATH + ".quick-buy-category";
     public static final String SHOP_SETTINGS_QUICK_BUY_BUTTON_MATERIAL = SHOP_SETTINGS_QUICK_BUY_CATEGORY_PATH + ".material";

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -270,7 +270,8 @@ public class ConfigPath {
     public static final String GENERAL_EGGBRIDGE_MAX_LENGTH = GENERAL_EGGBRIDGE+".max-length";
     public static final String GENERAL_EGGBRIDGE_MAX_HEIGHT = GENERAL_EGGBRIDGE+".max-height";
     public static final String GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT = GENERAL_EGGBRIDGE+".when-used-close-to-build-limit";
-    public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-build-limit";
+    public static final String GENERAL_EGGBRIDGE_MAX_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-max-build-limit";
+    public static final String GENERAL_EGGBRIDGE_MIN_BUILD_LIMIT_WARNING_DISTANCE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".close-distance-from-min-build-limit";
     public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".send-warn-message";
     public static final String GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE = GENERAL_EGGBRIDGE_USED_CLOSE_TO_BUILD_LIMIT +".cancel-usage";
 
@@ -309,6 +310,7 @@ public class ConfigPath {
     public static final String SHOP_SPECIAL_SILVERFISH_DAMAGE = SHOP_SPECIALS_PATH + ".silverfish.damage";
     public static final String SHOP_SPECIAL_SILVERFISH_SPEED = SHOP_SPECIALS_PATH + ".silverfish.speed";
     public static final String SHOP_SPECIAL_SILVERFISH_DESPAWN = SHOP_SPECIALS_PATH + ".silverfish.despawn";
+
 
     public static final String SHOP_SPECIAL_IRON_GOLEM_ENABLE = SHOP_SPECIALS_PATH + ".iron-golem.enable";
     public static final String SHOP_SPECIAL_IRON_GOLEM_MATERIAL = SHOP_SPECIALS_PATH + ".iron-golem.material";

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
@@ -50,18 +50,20 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class VersionSupport {
 
-    private static String name2;
+    private static final ConcurrentHashMap<UUID, Despawnable> despawnables = new ConcurrentHashMap<>();
     public static String PLUGIN_TAG_GENERIC_KEY = "BedWars2023";
     public static String PLUGIN_TAG_TIER_KEY = "tierIdentifier";
-
-    private Effect eggBridge;
-
-    private static final ConcurrentHashMap<UUID, Despawnable> despawnables = new ConcurrentHashMap<>();
+    private static String name2;
     private final Plugin plugin;
+    private Effect eggBridge;
 
     public VersionSupport(Plugin plugin, String versionName) {
         name2 = versionName;
         this.plugin = plugin;
+    }
+
+    public static String getName() {
+        return name2;
     }
 
     protected void loadDefaultEffects() {
@@ -101,7 +103,6 @@ public abstract class VersionSupport {
      * Hide an entity
      */
     public abstract void hideEntity(Entity e, Player p);
-
 
     /**
      * Check if item-stack is armor
@@ -168,12 +169,12 @@ public abstract class VersionSupport {
     /**
      * Spawn silverfish for a team
      */
-    public abstract void spawnSilverfish(Location loc, ITeam team, double speed, double health, int despawn, double damage);
+    public abstract void spawnSilverfish(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks);
 
     /**
      * Spawn a iron-golem for a team
      */
-    public abstract void spawnIronGolem(Location loc, ITeam team, double speed, double health, int despawn);
+    public abstract void spawnIronGolem(Location loc, ITeam team, double speed, double health, int despawn, int pathFindingTicks);
 
     /**
      * Is despawnable entity
@@ -401,16 +402,16 @@ public abstract class VersionSupport {
     /**
      * Red glass pane item stack
      *
-     * @return the itemStack
      * @param amount the amount of the stack
+     * @return the itemStack
      */
     public abstract ItemStack redGlassPane(int amount);
 
     /**
      * Green glass pane item stack
      *
-     * @return the itemStack
      * @param amount the amount of the stack
+     * @return the itemStack
      */
     public abstract ItemStack greenGlassPane(int amount);
 
@@ -456,11 +457,6 @@ public abstract class VersionSupport {
         return despawnables;
     }
 
-
-    public static String getName() {
-        return name2;
-    }
-
     public abstract int getVersion();
 
     public Plugin getPlugin() {
@@ -499,7 +495,7 @@ public abstract class VersionSupport {
 
     public abstract void clearArrowsFromPlayerBody(Player player);
 
-    public abstract Block placeTowerBlocks(Block b, IArena a, TeamColor color, int x, int y,int z);
+    public abstract Block placeTowerBlocks(Block b, IArena a, TeamColor color, int x, int y, int z);
 
     public abstract Block placeLadder(Block b, int x, int y, int z, IArena a, int ladderdata);
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -148,7 +148,8 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MIN_DISTANCE_FROM_PLAYER, 4.0);
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MAX_LENGTH, 27);
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MAX_HEIGHT, 9);
-        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE, 2);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MAX_BUILD_LIMIT_WARNING_DISTANCE, 5);
+        yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_MIN_BUILD_LIMIT_WARNING_DISTANCE, 3);
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER, false);
         yml.addDefault(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE, false);
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
@@ -65,6 +65,8 @@ import org.bukkit.util.Vector;
 import java.text.DecimalFormat;
 import java.util.Map;
 
+import static com.tomkeuper.bedwars.BedWars.plugin;
+import static com.tomkeuper.bedwars.BedWars.shop;
 import static com.tomkeuper.bedwars.api.language.Language.getMsg;
 
 public class DamageDeathMove implements Listener {
@@ -253,13 +255,47 @@ public class DamageDeathMove implements Listener {
                             }
                         } else return;
                     }
-                } else if ((e.getDamager() instanceof Silverfish) || (e.getDamager() instanceof IronGolem)) {
+                } else if ((e.getDamager() instanceof Silverfish)) {
                     LastHit lh = LastHit.getLastHit(p);
                     if (lh != null) {
                         lh.setDamager(e.getDamager());
                         lh.setTime(System.currentTimeMillis());
                     } else {
                         new LastHit(p, e.getDamager(), System.currentTimeMillis());
+                    }
+
+                    if (a.getShowTime().containsKey(p) && BedWars.shop.getBoolean(ConfigPath.SHOP_SPECIAL_SILVERFISH_REMOVES_INVISIBILITY)) {
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            for (Player on : a.getWorld().getPlayers()) {
+                                BedWars.nms.showArmor(p, on);
+                            }
+                            a.getShowTime().remove(p);
+                            p.removePotionEffect(PotionEffectType.INVISIBILITY);
+                            ITeam team = a.getTeam(p);
+                            p.sendMessage(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN));
+                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.REMOVED, team, p, a));
+                        });
+                    }
+                } else if (e.getDamager() instanceof IronGolem) {
+                    LastHit lh = LastHit.getLastHit(p);
+                    if (lh != null) {
+                        lh.setDamager(e.getDamager());
+                        lh.setTime(System.currentTimeMillis());
+                    } else {
+                        new LastHit(p, e.getDamager(), System.currentTimeMillis());
+                    }
+
+                    if (a.getShowTime().containsKey(p) && BedWars.shop.getBoolean(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_REMOVES_INVISIBILITY)) {
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            for (Player on : a.getWorld().getPlayers()) {
+                                BedWars.nms.showArmor(p, on);
+                            }
+                            a.getShowTime().remove(p);
+                            p.removePotionEffect(PotionEffectType.INVISIBILITY);
+                            ITeam team = a.getTeam(p);
+                            p.sendMessage(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN));
+                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.REMOVED, team, p, a));
+                        });
                     }
                 }
                 if (damager != null) {
@@ -285,7 +321,7 @@ public class DamageDeathMove implements Listener {
                     // #274
                     // if player gets hit show him
                     if (a.getShowTime().containsKey(p)) {
-                        Bukkit.getScheduler().runTask(BedWars.plugin, () -> {
+                        Bukkit.getScheduler().runTask(plugin, () -> {
                             for (Player on : a.getWorld().getPlayers()) {
                                 BedWars.nms.showArmor(p, on);
                                 //BedWars.nms.showPlayer(p, on);
@@ -524,7 +560,7 @@ public class DamageDeathMove implements Listener {
 
         // send respawn packet
         // Needs a delay to prevent hit delay but after respawning (mainly caused by projectile hits)
-        Bukkit.getScheduler().runTask(BedWars.plugin, () -> victim.spigot().respawn());
+        Bukkit.getScheduler().runTask(plugin, () -> victim.spigot().respawn());
         a.addPlayerDeath(victim);
 
         // reset last damager
@@ -573,8 +609,8 @@ public class DamageDeathMove implements Listener {
         ITeam t = a.getTeam(player);
         if (t == null) {
             e.setRespawnLocation(a.getReSpawnLocation());
-            BedWars.plugin.getLogger().severe(e.getPlayer().getName() + " re-spawn error on " + a.getArenaName() + "[" + a.getWorldName() + "] because the team was NULL and he was not spectating!");
-            BedWars.plugin.getLogger().severe("This is caused by one of your plugins: remove or configure any re-spawn related plugins.");
+            plugin.getLogger().severe(e.getPlayer().getName() + " re-spawn error on " + a.getArenaName() + "[" + a.getWorldName() + "] because the team was NULL and he was not spectating!");
+            plugin.getLogger().severe("This is caused by one of your plugins: remove or configure any re-spawn related plugins.");
             a.removePlayer(player, false);
             a.removeSpectator(player, false);
             return;
@@ -589,7 +625,7 @@ public class DamageDeathMove implements Listener {
                 for (Player p : a.getWorld().getPlayers()) {
                     p.sendMessage(getMsg(p, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", t.getColor().chat().toString()).replace("%bw_team_name%", t.getDisplayName(Language.getPlayerLanguage(p))));
                 }
-                Bukkit.getScheduler().runTaskLater(BedWars.plugin, a::checkWinner, 40L);
+                Bukkit.getScheduler().runTaskLater(plugin, a::checkWinner, 40L);
             }
         } else {
             //respawn session
@@ -783,9 +819,15 @@ public class DamageDeathMove implements Listener {
     @SuppressWarnings("unused")
     private static void spawnUtility(String s, Location loc, ITeam t, Player p) {
         if ("silverfish".equalsIgnoreCase(s)) {
-            BedWars.nms.spawnSilverfish(loc, t, BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_SPEED), BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_HEALTH),
+            BedWars.nms.spawnSilverfish(
+                    loc,
+                    t,
+                    BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_SPEED),
+                    BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_HEALTH),
                     BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_SILVERFISH_DESPAWN),
-                    BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_DAMAGE));
+                    BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_DAMAGE),
+                    BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_SILVERFISH_PATH_FINDING_TICKS)
+            );
         }
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
@@ -24,11 +24,11 @@ import com.tomkeuper.bedwars.BedWars;
 import com.tomkeuper.bedwars.api.arena.IArena;
 import com.tomkeuper.bedwars.api.configuration.ConfigPath;
 import com.tomkeuper.bedwars.api.events.gameplay.EggBridgeThrowEvent;
+import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.ServerType;
 import com.tomkeuper.bedwars.arena.Arena;
 import com.tomkeuper.bedwars.arena.tasks.EggBridgeTask;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Egg;
@@ -37,7 +37,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
@@ -45,61 +44,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.tomkeuper.bedwars.BedWars.config;
+import static com.tomkeuper.bedwars.api.language.Language.getMsg;
 
 @SuppressWarnings("WeakerAccess")
 public class EggBridge implements Listener {
 
     //Active eggBridges
     private static final Map<Egg, EggBridgeTask> bridges = new HashMap<>();
-
-    @EventHandler
-    public void onLaunch(ProjectileLaunchEvent event) {
-        if (BedWars.getServerType() == ServerType.MULTIARENA) {
-            if (event.getEntity().getLocation().getWorld().getName().equalsIgnoreCase(BedWars.getLobbyWorld())) {
-                event.setCancelled(true);
-                return;
-            }
-        }
-        if (event.getEntity() instanceof Egg) {
-            Egg projectile = (Egg) event.getEntity();
-            if (projectile.getShooter() instanceof Player) {
-                Player shooter = (Player) projectile.getShooter();
-                IArena arena = Arena.getArenaByPlayer(shooter);
-                if (arena != null) {
-                    if (arena.isPlayer(shooter)) {
-                        if (shooter.getLocation().getY() > arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y) - config.getInt(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE)
-                                || shooter.getLocation().getY() < arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y) + config.getInt(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARNING_DISTANCE)) {
-                            if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER)) {
-                                shooter.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cTúl közel vagy az építési limithez!"));
-                            }
-                            if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE)) {
-                                if (shooter.getGameMode() != GameMode.CREATIVE) {
-                                    shooter.getInventory().addItem(new ItemStack(Material.EGG, 1));
-                                }
-                                event.setCancelled(true);
-                                return;
-                            }
-                        }
-
-                        EggBridgeThrowEvent throwEvent = new EggBridgeThrowEvent(shooter, arena);
-                        Bukkit.getPluginManager().callEvent(throwEvent);
-                        if (event.isCancelled()) {
-                            event.setCancelled(true);
-                            return;
-                        }
-                        bridges.put(projectile, new EggBridgeTask(shooter, projectile, arena.getTeam(shooter).getColor()));
-                    }
-                }
-            }
-        }
-    }
-
-    @EventHandler
-    public void onHit(ProjectileHitEvent e) {
-        if (e.getEntity() instanceof Egg) {
-            removeEgg((Egg) e.getEntity());
-        }
-    }
 
     /**
      * Remove an egg from the active eggs list
@@ -123,5 +74,67 @@ public class EggBridge implements Listener {
      */
     public static Map<Egg, EggBridgeTask> getBridges() {
         return Collections.unmodifiableMap(bridges);
+    }
+
+    @EventHandler
+    public void onLaunch(ProjectileLaunchEvent event) {
+        if (BedWars.getServerType() == ServerType.MULTIARENA) {
+            if (event.getEntity().getLocation().getWorld().getName().equalsIgnoreCase(BedWars.getLobbyWorld())) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        if (event.getEntity() instanceof Egg) {
+            Egg projectile = (Egg) event.getEntity();
+            if (!(projectile.getShooter() instanceof Player)) {
+                return;
+            }
+
+            Player shooter = (Player) projectile.getShooter();
+            IArena arena = Arena.getArenaByPlayer(shooter);
+            if (arena == null) {
+                return;
+            }
+
+            if (!arena.isPlayer(shooter)) {
+                return;
+            }
+
+            boolean isCloseToMaxBuildLimit = shooter.getLocation().getY() > arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y) - config.getInt(ConfigPath.GENERAL_EGGBRIDGE_MAX_BUILD_LIMIT_WARNING_DISTANCE);
+            boolean isCloseToMinBuildLimit = shooter.getLocation().getY() < arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y) + config.getInt(ConfigPath.GENERAL_EGGBRIDGE_MIN_BUILD_LIMIT_WARNING_DISTANCE);
+            boolean isUnderBuildLimit = shooter.getLocation().getY() < arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y);
+            boolean isAboveLimit = shooter.getLocation().getY() > arena.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y);
+            boolean isLookingUp = shooter.getLocation().getPitch() < -5.0;
+            boolean isLookingDown = shooter.getLocation().getPitch() > 5.0;
+
+            if ((isCloseToMaxBuildLimit && isLookingUp) || (isCloseToMinBuildLimit && isLookingDown) || isUnderBuildLimit || isAboveLimit) {
+                if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER)) {
+                    shooter.sendMessage(getMsg(shooter, Messages.EGGBRIDGE_BUILD_LIMIT_WARNING));
+                }
+                if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE)) {
+                    if (shooter.getGameMode() != GameMode.CREATIVE) {
+                        shooter.getInventory().addItem(new ItemStack(Material.EGG, 1));
+                    }
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            EggBridgeThrowEvent throwEvent = new EggBridgeThrowEvent(shooter, arena);
+            Bukkit.getPluginManager().callEvent(throwEvent);
+            if (event.isCancelled()) {
+                event.setCancelled(true);
+                return;
+            }
+
+            bridges.put(projectile, new EggBridgeTask(shooter, projectile, arena.getTeam(shooter).getColor()));
+        }
+    }
+
+    @EventHandler
+    public void onHit(ProjectileHitEvent e) {
+        if (e.getEntity() instanceof Egg) {
+            removeEgg((Egg) e.getEntity());
+        }
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/ShopManager.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/ShopManager.java
@@ -75,19 +75,23 @@ public class ShopManager extends ConfigManager implements IShopManager {
 
         //specials
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_ENABLE, true);
+        getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_REMOVES_INVISIBILITY, false);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_MATERIAL, BedWars.getForCurrentVersion("SNOW_BALL", "SNOW_BALL", "SNOWBALL"));
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_DATA, 0);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_HEALTH, 8.0);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_DAMAGE, 4.0);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_SPEED, 0.25);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_DESPAWN, 15);
+        getYml().addDefault(ConfigPath.SHOP_SPECIAL_SILVERFISH_PATH_FINDING_TICKS, 20);
 
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_ENABLE, true);
+        getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_REMOVES_INVISIBILITY, false);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_MATERIAL, BedWars.getForCurrentVersion("MONSTER_EGG", "MONSTER_EGG", "HORSE_SPAWN_EGG"));
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_DATA, 0);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_HEALTH, 100.0);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_DESPAWN, 240);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_SPEED, 0.25);
+        getYml().addDefault(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_PATH_FINDING_TICKS, 20);
 
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_TOWER_ENABLE, true);
         getYml().addDefault(ConfigPath.SHOP_SPECIAL_TOWER_MATERIAL, BedWars.getForCurrentVersion("CHEST", "CHEST", "CHEST"));

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/listeners/SpecialsListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/listeners/SpecialsListener.java
@@ -59,9 +59,15 @@ public class SpecialsListener implements Listener {
                     e.setCancelled(true);
                     ITeam playerTeam = a.getTeam(p);
                     PlayerBedBugSpawnEvent event = new PlayerBedBugSpawnEvent(p, playerTeam, a);
-                    BedWars.nms.spawnSilverfish(p.getTargetBlock((Set<Material>) null, 5).getLocation().add(0, 1, 0), playerTeam, BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_SPEED),
-                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_HEALTH), BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_SILVERFISH_DESPAWN),
-                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_DAMAGE));
+                    BedWars.nms.spawnSilverfish(
+                            p.getTargetBlock((Set<Material>) null, 5).getLocation().add(0, 1, 0),
+                            playerTeam,
+                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_SPEED),
+                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_HEALTH),
+                            BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_SILVERFISH_DESPAWN),
+                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_SILVERFISH_DAMAGE),
+                            BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_SILVERFISH_PATH_FINDING_TICKS)
+                    );
                     Bukkit.getPluginManager().callEvent(event);
                     if (!BedWars.nms.isProjectile(i)) {
                         BedWars.nms.minusAmount(p, i, 1);
@@ -77,8 +83,14 @@ public class SpecialsListener implements Listener {
                     e.setCancelled(true);
                     ITeam playerTeam = a.getTeam(p);
                     PlayerDreamDefenderSpawnEvent event = new PlayerDreamDefenderSpawnEvent(p, playerTeam, a);
-                    BedWars.nms.spawnIronGolem(p.getTargetBlock((Set<Material>) null, 5).getLocation().add(0, 1, 0), playerTeam, BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_SPEED),
-                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_HEALTH), BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_DESPAWN));
+                    BedWars.nms.spawnIronGolem(
+                            p.getTargetBlock((Set<Material>) null, 5).getLocation().add(0, 1, 0),
+                            playerTeam,
+                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_SPEED),
+                            BedWars.shop.getYml().getDouble(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_HEALTH),
+                            BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_DESPAWN),
+                            BedWars.shop.getInt(ConfigPath.SHOP_SPECIAL_IRON_GOLEM_PATH_FINDING_TICKS)
+                    );
                     Bukkit.getPluginManager().callEvent(event);
                     if (!BedWars.nms.isProjectile(i)) {
                         BedWars.nms.minusAmount(p, i, 1);

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/IGolem.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/IGolem.java
@@ -39,7 +39,7 @@ public class IGolem extends EntityIronGolem {
 
     private ITeam team;
 
-    private IGolem(World world, ITeam team) {
+    private IGolem(World world, ITeam team, int pathFindingTicks) {
         super(world);
         this.team = team;
         try {
@@ -61,14 +61,14 @@ public class IGolem extends EntityIronGolem {
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, true));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 1D));
         this.goalSelector.a(4, new PathfinderGoalRandomLookaround(this));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             return ((Silverfish)sf).getTeam() != team;
         }));
     }
@@ -77,9 +77,9 @@ public class IGolem extends EntityIronGolem {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld)loc.getWorld()).getHandle();
-        IGolem customEnt = new IGolem(mcWorld, bedWarsTeam);
+        IGolem customEnt = new IGolem(mcWorld, bedWarsTeam, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         ((CraftLivingEntity)customEnt.getBukkitEntity()).setRemoveWhenFarAway(false);
         customEnt.setCustomNameVisible(true);

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/Silverfish.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/Silverfish.java
@@ -43,7 +43,7 @@ public class Silverfish extends EntitySilverfish {
     private ITeam team;
 
     @SuppressWarnings("WeakerAccess")
-    public Silverfish(World world, ITeam team) {
+    public Silverfish(World world, ITeam team, int pathFindingTicks) {
         super(world);
         try {
             Field bField = PathfinderGoalSelector.class.getDeclaredField("b");
@@ -62,14 +62,14 @@ public class Silverfish extends EntitySilverfish {
         this.goalSelector.a(2, new PathfinderGoalMeleeAttack(this,1.9D, false));
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, true));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 2D));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             return ((Silverfish)sf).getTeam() != team;
         }));
     }
@@ -135,9 +135,9 @@ public class Silverfish extends EntitySilverfish {
         }
     }
 
-    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage) {
+    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld)loc.getWorld()).getHandle();
-        Silverfish customEnt = new Silverfish(mcWorld, team);
+        Silverfish customEnt = new Silverfish(mcWorld, team, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         customEnt.getAttributeInstance(GenericAttributes.maxHealth).setValue(health);
         customEnt.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED).setValue(speed);

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -116,14 +116,14 @@ public class v1_12_R1 extends VersionSupport {
         }
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
-        new Despawnable(com.tomkeuper.bedwars.support.version.v1_12_R1.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage), bedWarsTeam, despawn,
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        new Despawnable(com.tomkeuper.bedwars.support.version.v1_12_R1.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage, pathFindingTicks), bedWarsTeam, despawn,
                 Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL, PlayerKillEvent.PlayerKillCause.SILVERFISH);
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
-        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn, pathFindingTicks), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
                 PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL, PlayerKillEvent.PlayerKillCause.IRON_GOLEM);
     }
 

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/IGolem.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/IGolem.java
@@ -40,7 +40,7 @@ public class IGolem extends EntityIronGolem {
 
     private ITeam team;
 
-    private IGolem(World world, ITeam team) {
+    private IGolem(World world, ITeam team, int pathFindingTicks) {
         super(world);
         this.team = team;
         try {
@@ -62,16 +62,16 @@ public class IGolem extends EntityIronGolem {
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, true));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 1D));
         this.goalSelector.a(4, new PathfinderGoalRandomLookaround(this));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             if (player == null) return false;
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             if (golem == null) return false;
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             if (sf == null) return false;
             return ((Silverfish)sf).getTeam() != team;
         }));
@@ -81,9 +81,9 @@ public class IGolem extends EntityIronGolem {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld) loc.getWorld()).getHandle();
-        IGolem customEnt = new IGolem(mcWorld, bedWarsTeam);
+        IGolem customEnt = new IGolem(mcWorld, bedWarsTeam, pathFindingTicks);
 
         customEnt.getAttributeInstance(GenericAttributes.maxHealth).setValue(health);
         customEnt.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED).setValue(speed);

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/Silverfish.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/Silverfish.java
@@ -40,7 +40,7 @@ public class Silverfish extends EntitySilverfish {
 
     private ITeam team;
 
-    public Silverfish(World world, ITeam bedWarsTeam) {
+    public Silverfish(World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(world);
         if (bedWarsTeam == null) return;
         try {
@@ -60,16 +60,16 @@ public class Silverfish extends EntitySilverfish {
         this.goalSelector.a(2, new PathfinderGoalMeleeAttack(this,1.9D, false));
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, true));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 2D));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             if (player == null) return false;
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             if (golem == null) return false;
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             if (sf == null) return false;
             return ((Silverfish)sf).getTeam() != team;
         }));
@@ -79,9 +79,9 @@ public class Silverfish extends EntitySilverfish {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage) {
+    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld)loc.getWorld()).getHandle();
-        Silverfish customEnt = new Silverfish(mcWorld, team);
+        Silverfish customEnt = new Silverfish(mcWorld, team, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         customEnt.getAttributeInstance(GenericAttributes.maxHealth).setValue(health);
         customEnt.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED).setValue(speed);

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -77,14 +77,14 @@ public class v1_8_R3 extends VersionSupport {
         }
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
-        new Despawnable(com.tomkeuper.bedwars.support.version.v1_8_R3.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage), bedWarsTeam, despawn,
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        new Despawnable(com.tomkeuper.bedwars.support.version.v1_8_R3.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage, pathFindingTicks), bedWarsTeam, despawn,
                 Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL, PlayerKillEvent.PlayerKillCause.SILVERFISH);
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
-        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn, pathFindingTicks), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
                 PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL, PlayerKillEvent.PlayerKillCause.IRON_GOLEM);
     }
 

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/IGolem.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/IGolem.java
@@ -34,10 +34,12 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 
 public class IGolem extends EntityIronGolem {
     private ITeam team;
+    private int pathFindingTicks;
 
-    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam) {
+    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     public IGolem(EntityTypes entityTypes, World world) {
@@ -51,21 +53,21 @@ public class IGolem extends EntityIronGolem {
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 1D));
         this.goalSelector.a(4, new PathfinderGoalRandomLookaround(this));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return player.isAlive() && !team.wasMember(player.getUniqueID()) && !team.getArena().isReSpawning(player.getUniqueID())
                     && !team.getArena().isSpectator(player.getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, IGolem.class, 20, true, false, golem -> ((IGolem)golem).getTeam() != team));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget<>(this, Silverfish.class, 20, true, false, sf -> ((Silverfish)sf).getTeam() != team));
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, IGolem.class, pathFindingTicks, true, false, golem -> ((IGolem)golem).getTeam() != team));
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget<>(this, Silverfish.class, pathFindingTicks, true, false, sf -> ((Silverfish)sf).getTeam() != team));
     }
 
     public ITeam getTeam() {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld) loc.getWorld()).getHandle();
-        IGolem customEnt = new IGolem(EntityTypes.IRON_GOLEM, mcWorld, bedWarsTeam);
+        IGolem customEnt = new IGolem(EntityTypes.IRON_GOLEM, mcWorld, bedWarsTeam, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         ((CraftLivingEntity) customEnt.getBukkitEntity()).setRemoveWhenFarAway(false);
         customEnt.setCustomNameVisible(true);

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/Silverfish.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/Silverfish.java
@@ -35,10 +35,12 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 public class Silverfish extends EntitySilverfish {
 
     private ITeam team;
+    private int pathFindingTicks;
 
-    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, net.minecraft.server.v1_16_R3.World world, ITeam bedWarsTeam) {
+    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, net.minecraft.server.v1_16_R3.World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     @SuppressWarnings("unchecked")
@@ -52,14 +54,14 @@ public class Silverfish extends EntitySilverfish {
         this.goalSelector.a(2, new PathfinderGoalMeleeAttack(this,1.9D, false));
         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this));
         this.goalSelector.a(3, new PathfinderGoalRandomStroll(this, 2D));
-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             return ((Silverfish)sf).getTeam() != team;
         }));
     }
@@ -68,9 +70,9 @@ public class Silverfish extends EntitySilverfish {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage) {
+    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld)loc.getWorld()).getHandle();
-        Silverfish customEnt = new Silverfish(EntityTypes.SILVERFISH, mcWorld, team);
+        Silverfish customEnt = new Silverfish(EntityTypes.SILVERFISH, mcWorld, team, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         customEnt.getAttributeInstance(GenericAttributes.MAX_HEALTH).setValue(health);
         customEnt.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED).setValue(speed);

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -103,14 +103,14 @@ public class v1_16_R3 extends VersionSupport {
         p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
-        new Despawnable(Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage), bedWarsTeam, despawn,
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        new Despawnable(Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage, pathFindingTicks), bedWarsTeam, despawn,
                 Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL, PlayerKillEvent.PlayerKillCause.SILVERFISH);
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
-        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn, pathFindingTicks), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
                 PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL, PlayerKillEvent.PlayerKillCause.IRON_GOLEM);
     }
 

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/IGolem.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/IGolem.java
@@ -49,10 +49,12 @@ import java.util.Objects;
 @SuppressWarnings("unchecked")
 public class IGolem extends EntityIronGolem {
     private ITeam team;
+    private int pathFindingTicks;
 
-    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam) {
+    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     public IGolem(EntityTypes entityTypes, World world) {
@@ -68,18 +70,18 @@ public class IGolem extends EntityIronGolem {
         this.bP.a(3, new PathfinderGoalRandomStroll(this, 1D));
         this.bP.a(4, new PathfinderGoalRandomLookaround(this));
         this.bQ.a(2, new PathfinderGoalNearestAttackableTarget(
-                this, EntityHuman.class, 20, true, false,
+                this, EntityHuman.class, pathFindingTicks, true, false,
                 player -> ((EntityHuman)player).isAlive() &&
                         !team.wasMember(((EntityHuman)player).getUniqueID()) &&
                         !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                 && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID()))
         );
         this.bQ.a(3, new PathfinderGoalNearestAttackableTarget(
-                this, IGolem.class, 20, true, false,
+                this, IGolem.class, pathFindingTicks, true, false,
                 golem -> ((IGolem)golem).getTeam() != team)
         );
         this.bQ.a(4, new PathfinderGoalNearestAttackableTarget(
-                this, Silverfish.class, 20, true, false,
+                this, Silverfish.class, pathFindingTicks, true, false,
                 sf -> ((Silverfish)sf).getTeam() != team)
         );
     }
@@ -88,9 +90,9 @@ public class IGolem extends EntityIronGolem {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld) Objects.requireNonNull(loc.getWorld())).getHandle();
-        IGolem customEnt = new IGolem(EntityTypes.P, mcWorld, bedWarsTeam);
+        IGolem customEnt = new IGolem(EntityTypes.P, mcWorld, bedWarsTeam, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         ((CraftLivingEntity) customEnt.getBukkitEntity()).setRemoveWhenFarAway(false);
         customEnt.setCustomNameVisible(true);

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/Silverfish.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/Silverfish.java
@@ -46,10 +46,12 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 public class Silverfish extends EntitySilverfish {
 
     private ITeam team;
+    private int pathFindingTicks;
 
-    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, World world, ITeam bedWarsTeam) {
+    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     @SuppressWarnings("unchecked")
@@ -63,14 +65,14 @@ public class Silverfish extends EntitySilverfish {
         this.bP.a(2, new PathfinderGoalMeleeAttack(this,1.9D, false));
         this.bQ.a(1, new PathfinderGoalHurtByTarget(this));
         this.bP.a(3, new PathfinderGoalRandomStroll(this, 2D));
-        this.bQ.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.bQ.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return ((EntityHuman)player).isAlive() && !team.wasMember(((EntityHuman)player).getUniqueID()) && !team.getArena().isReSpawning(((EntityHuman)player).getUniqueID())
                     && !team.getArena().isSpectator(((EntityHuman)player).getUniqueID());
         }));
-        this.bQ.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.bQ.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             return ((IGolem)golem).getTeam() != team;
         }));
-        this.bQ.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.bQ.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             return ((Silverfish)sf).getTeam() != team;
         }));
     }
@@ -79,9 +81,9 @@ public class Silverfish extends EntitySilverfish {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage) {
+    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld)loc.getWorld()).getHandle();
-        Silverfish customEnt = new Silverfish(EntityTypes.aA, mcWorld, team);
+        Silverfish customEnt = new Silverfish(EntityTypes.aA, mcWorld, team, pathFindingTicks);
         customEnt.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         customEnt.getAttributeInstance(GenericAttributes.a).setValue(health);
         customEnt.getAttributeInstance(GenericAttributes.d).setValue(speed);

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -129,14 +129,14 @@ public class v1_17_R1 extends VersionSupport {
         p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
-        new Despawnable(com.tomkeuper.bedwars.support.version.v1_17_R1.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage), bedWarsTeam, despawn,
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        new Despawnable(com.tomkeuper.bedwars.support.version.v1_17_R1.Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage, pathFindingTicks), bedWarsTeam, despawn,
                 Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL, PlayerKillEvent.PlayerKillCause.SILVERFISH);
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
-        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn, pathFindingTicks), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
                 PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL, PlayerKillEvent.PlayerKillCause.IRON_GOLEM);
     }
 

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/IGolem.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/IGolem.java
@@ -50,10 +50,12 @@ import java.util.Objects;
 @SuppressWarnings("unchecked")
 public class IGolem extends EntityIronGolem {
     private ITeam team;
+    private int pathFindingTicks;
 
-    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam) {
+    private IGolem(EntityTypes<? extends EntityIronGolem> entitytypes, World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     public IGolem(EntityTypes entityTypes, World world) {
@@ -69,18 +71,18 @@ public class IGolem extends EntityIronGolem {
         this.bQ.a(4, new PathfinderGoalRandomStroll(this, 1D));
         this.bQ.a(5, new PathfinderGoalRandomLookaround(this));
         this.bR.a(6, new PathfinderGoalNearestAttackableTarget(
-                this, EntityHuman.class, 20, true, false,
+                this, EntityHuman.class, pathFindingTicks, true, false,
                 player -> !((EntityHuman)player).getBukkitEntity().isDead() &&
                         !team.wasMember(((EntityHuman)player).getBukkitEntity().getUniqueId()) &&
                         !team.getArena().isReSpawning(((EntityHuman)player).getBukkitEntity().getUniqueId())
                 && !team.getArena().isSpectator(((EntityHuman)player).getBukkitEntity().getUniqueId()))
         );
         this.bR.a(7, new PathfinderGoalNearestAttackableTarget(
-                this, IGolem.class, 20, true, false,
+                this, IGolem.class, pathFindingTicks, true, false,
                 golem -> ((IGolem)golem).getTeam() != team)
         );
         this.bR.a(8, new PathfinderGoalNearestAttackableTarget(
-                this, Silverfish.class, 20, true, false,
+                this, Silverfish.class, pathFindingTicks, true, false,
                 sf -> ((Silverfish)sf).getTeam() != team)
         );
     }
@@ -89,9 +91,9 @@ public class IGolem extends EntityIronGolem {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public static LivingEntity spawn(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld) Objects.requireNonNull(loc.getWorld())).getHandle();
-        IGolem customEnt = new IGolem(EntityTypes.P, mcWorld, bedWarsTeam);
+        IGolem customEnt = new IGolem(EntityTypes.P, mcWorld, bedWarsTeam, pathFindingTicks);
         customEnt.a(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         ((CraftLivingEntity) customEnt.getBukkitEntity()).setRemoveWhenFarAway(false);
         Objects.requireNonNull(customEnt.a(GenericAttributes.a)).a(health);

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/Silverfish.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/Silverfish.java
@@ -48,10 +48,12 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 public class Silverfish extends EntitySilverfish {
 
     private ITeam team;
+    private int pathFindingTicks;
 
-    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, World world, ITeam bedWarsTeam) {
+    private Silverfish(EntityTypes<? extends EntitySilverfish> entitytypes, World world, ITeam bedWarsTeam, int pathFindingTicks) {
         super(entitytypes, world);
         this.team = bedWarsTeam;
+        this.pathFindingTicks = pathFindingTicks;
     }
 
     @SuppressWarnings("unchecked")
@@ -65,16 +67,16 @@ public class Silverfish extends EntitySilverfish {
         this.bQ.a(2, new PathfinderGoalMeleeAttack(this, 1.9D, false));
         this.bR.a(1, new PathfinderGoalHurtByTarget(this));
         this.bQ.a(3, new PathfinderGoalRandomStroll(this, 2D));
-        this.bR.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, 20, true, false, player -> {
+        this.bR.a(2, new PathfinderGoalNearestAttackableTarget(this, EntityHuman.class, pathFindingTicks, true, false, player -> {
             return (!((EntityHuman) player).getBukkitEntity().isDead()) &&
                     (!team.wasMember(((EntityHuman) player).getBukkitEntity().getUniqueId())) &&
                     (!team.getArena().isReSpawning(((EntityHuman) player).getBukkitEntity().getUniqueId())) &&
                     (!team.getArena().isSpectator(((EntityHuman) player).getBukkitEntity().getUniqueId()));
         }));
-        this.bR.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, 20, true, false, golem -> {
+        this.bR.a(3, new PathfinderGoalNearestAttackableTarget(this, IGolem.class, pathFindingTicks, true, false, golem -> {
             return ((IGolem) golem).getTeam() != team;
         }));
-        this.bR.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, 20, true, false, sf -> {
+        this.bR.a(4, new PathfinderGoalNearestAttackableTarget(this, Silverfish.class, pathFindingTicks, true, false, sf -> {
             return ((Silverfish) sf).getTeam() != team;
         }));
     }
@@ -83,9 +85,9 @@ public class Silverfish extends EntitySilverfish {
         return team;
     }
 
-    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage) {
+    public static LivingEntity spawn(Location loc, ITeam team, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         WorldServer mcWorld = ((CraftWorld) loc.getWorld()).getHandle();
-        Silverfish customEnt = new Silverfish(EntityTypes.aA, mcWorld, team);
+        Silverfish customEnt = new Silverfish(EntityTypes.aA, mcWorld, team, pathFindingTicks);
         customEnt.a(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         customEnt.a(GenericAttributes.a).a(health);
         customEnt.a(GenericAttributes.d).a(speed);

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -121,14 +121,14 @@ public class v1_18_R2 extends VersionSupport {
         p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
-        new Despawnable(Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage), bedWarsTeam, despawn,
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        new Despawnable(Silverfish.spawn(loc, bedWarsTeam, speed, health, despawn, damage, pathFindingTicks), bedWarsTeam, despawn,
                 Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME, PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL, PlayerKillEvent.PlayerKillCause.SILVERFISH);
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
-        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        new Despawnable(IGolem.spawn(loc, bedWarsTeam, speed, health, despawn, pathFindingTicks), bedWarsTeam, despawn, Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
                 PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL, PlayerKillEvent.PlayerKillCause.IRON_GOLEM);
     }
 

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bN.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 entityLiving -> {
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
@@ -124,9 +124,9 @@ public class v1_19_R3 extends VersionSupport {
         p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
     }
 
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -138,9 +138,9 @@ public class v1_19_R3 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health,4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bT.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 entityLiving -> {
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
@@ -229,9 +229,9 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -243,9 +243,9 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bT.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 entityLiving -> {
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -229,9 +229,9 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -243,9 +243,9 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bX.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 entityLiving -> {
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -235,9 +235,9 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -249,9 +249,9 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bU.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 (entityLiving, sourceEntity) -> { // Two parameters now
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -231,9 +231,9 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -245,9 +245,9 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.bT.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 (entityLiving, sourceEntity) -> { // Two parameters now
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -231,9 +231,9 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -245,9 +245,9 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableFactory.java
@@ -40,8 +40,8 @@ public class DespawnableFactory {
         providers.add(new TeamSilverfish());
     }
 
-    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
         return providers.stream().filter(provider -> provider.getType() == attr.type())
-                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
     }
 }

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/DespawnableProvider.java
@@ -43,7 +43,7 @@ public abstract class DespawnableProvider<T> {
 
     abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
 
-    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
 
     protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
         var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
@@ -63,8 +63,8 @@ public abstract class DespawnableProvider<T> {
         entityLiving.ch.b().clear();
     }
 
-    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
-        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
                 (entityLiving, sourceEntity) -> { // Two parameters now
                     if (entityLiving instanceof EntityHuman) {
                         return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamIronGolem.java
@@ -55,7 +55,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         );
     }
 
-    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
 
         var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
         applyDefaultSettings(bukkitEntity, attr, team);
@@ -71,7 +71,7 @@ public class TeamIronGolem extends DespawnableProvider<IronGolem> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/despawnable/TeamSilverfish.java
@@ -55,7 +55,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     }
 
     @Override
-    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
         var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
         applyDefaultSettings(bukkitEntity, attr, team);
 
@@ -69,7 +69,7 @@ public class TeamSilverfish extends DespawnableProvider<Silverfish> {
         goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
         goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
         targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
-        targetSelector.a(2, getTargetGoal(entity, team, api));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
 
         return bukkitEntity;
     }

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -238,9 +238,9 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
-    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
 
         new Despawnable(
                 entity,
@@ -252,9 +252,9 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
-    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
         var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
-        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
         new Despawnable(
                 entity,
                 bedWarsTeam, despawn,


### PR DESCRIPTION
Hello!

So, the eggbridge now has a config section with the following settings (by default):
<img width="323" height="199" alt="image" src="https://github.com/user-attachments/assets/da7bb758-3119-4f6f-b6a4-45a7709dc308" />
Most of them are self explanatory, but we have the `when-used-close-to-build-limit` section. By default all of these function are turned off, but you can turn them on. These are made for to prevent wasting the eggbridge (like throwing it higher than the build limit, and it does nothing.)

If you turn these on, you can set the following options:
**`close-distance-from-max-build-limit:`** If a player throws an eggbridge and their y is in the 5 block range of the arena's maximum build limit or above it, and the player is looking upwards, than the plugin cancels the usage of the eggbridge and gives it back to the player and sends them a warning message, that can be configured in every language file.
**`close-distance-from-min-build-limit:`** If a player throws an eggbridge and their y is in the 3 block range of the arena's minimum build limit or under it, and the player is looking downwards, than the plugin cancels the usage of the eggbridge and gives it back to the player and sends them a warning message, that can be configured in every language file.

The cancellation of the eggbridge usage and the message can be disabled.

**Here is a video of the things I made:**
https://youtu.be/s4q9Vk4zDDE