### PR TITLE
51 game end no winner

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/language/Messages.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/language/Messages.java
@@ -331,6 +331,7 @@ public class Messages {
     public static String GAME_END_THIRD_KILLER = "game-end-third-killer";
     public static String GAME_END_TOP_PLAYER_CHAT = "game-end-top-chat";
     public static String GAME_END_TEAM_WON_CHAT = "game-end-winner-team";
+    public static String GAME_END_NO_WINNERS = "game-end-no-winners";
     public static String XP_REWARD_WIN = "xp-reward-game-win";
     public static String XP_REWARD_PER_TEAMMATE = "xp-reward-per-teammate";
     public static String XP_REWARD_PER_MINUTE = "xp-reward-per-minute";

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -2194,13 +2194,13 @@ public class Arena implements IArena {
             setNextEvent(NextEvent.ENDER_DRAGON);
         } else if (nextEvent == NextEvent.ENDER_DRAGON && getPlayingTask().getDragonSpawnCountdown() == 0) {
             setNextEvent(NextEvent.GAME_END);
-            if(players)
+            if(!getPlayers().isEmpty())
                 for (Player p : getPlayers()) {
-                    p.sendMassage(getMsg(p, Messages.GAME_END_NO_WINNERS));
+                    p.sendMessage(getMsg(p, Messages.GAME_END_NO_WINNERS));
                 }
-            if(spectators)
+            if(!getSpectators().isEmpty())
                 for (Player p : getSpectators()) {
-                    p.sendMassage(getMsg(p, Messages.GAME_END_NO_WINNERS));
+                    p.sendMessage(getMsg(p, Messages.GAME_END_NO_WINNERS));
             }
         }
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -2194,6 +2194,14 @@ public class Arena implements IArena {
             setNextEvent(NextEvent.ENDER_DRAGON);
         } else if (nextEvent == NextEvent.ENDER_DRAGON && getPlayingTask().getDragonSpawnCountdown() == 0) {
             setNextEvent(NextEvent.GAME_END);
+            if(players)
+                for (Player p : getPlayers()) {
+                    p.sendMassage(getMsg(p, Messages.GAME_END_NO_WINNERS));
+                }
+            if(spectators)
+                for (Player p : getSpectators()) {
+                    p.sendMassage(getMsg(p, Messages.GAME_END_NO_WINNERS));
+            }
         }
 
         debug("---");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Bangla.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Bangla.java
@@ -296,6 +296,7 @@ public class Bangla extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lGAME SHES!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lBIJOY!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &ateam khela jitlen!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNénten wénten pemenang galahé puniki!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/English.java
@@ -297,6 +297,7 @@ public class English extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lGAME OVER!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lVICTORY!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &ahas won the game!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNo winners this time!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Hindi.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Hindi.java
@@ -296,6 +296,7 @@ public class Hindi extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lGAME KHATAM HO GAYA!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lVIJAY!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &ateam game jeete!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cKoee bhee khel nahin jeet paaya hai!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Indonesia.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Indonesia.java
@@ -295,6 +295,7 @@ public class Indonesia extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lPERMAINAN SELESAI!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lKEMENANGAN!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &atelah memenangkan permainan!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cTidak ada seorang pun yang memenangkan permainan ini!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Italian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Italian.java
@@ -308,6 +308,7 @@ public class Italian extends Language {
                 "&c                          &l3rd Killer &7- %bw_third_format% - %bw_third_kills%", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &aha vinto il gioco!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNessuno ha vinto la partita!");
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDifendi il tuo letto!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lIl tuo letto è stato distrutto!");
         yml.addDefault(Messages.NEXT_EVENT_BEDS_DESTROY, "&fRompere Letto");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Persian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Persian.java
@@ -297,6 +297,7 @@ public class Persian extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lBAZI TAMOOM SHOD!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lBORD!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &abarande bazi shodan!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cCpehich kes bazi ra nabardeh est!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Polish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Polish.java
@@ -304,6 +304,7 @@ public class Polish extends Language{
                 "&c                          &l3rd Killer &7- %bw_third_format% - %bw_third_kills%", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &awygral gre!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNikt nie wygrał gry!");
         yml.addDefault(Messages.NEXT_EVENT_BEDS_DESTROY, "&fZniszczenie lozek");
         yml.addDefault(Messages.NEXT_EVENT_DIAMOND_UPGRADE_II, "&fDiament &cII");
         yml.addDefault(Messages.NEXT_EVENT_DIAMOND_UPGRADE_III, "&fDiament &cIII");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Portuguese.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Portuguese.java
@@ -295,6 +295,7 @@ public class Portuguese extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lFIM DE JOGO!");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lVITÓRIA!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &aganhou o jogo!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNinguém ganhou o jogo!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Romanian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Romanian.java
@@ -302,6 +302,7 @@ public class Romanian extends Language {
                 "&c                          &l3rd Killer &7- %bw_third_format% - %bw_third_kills%", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%Echipa %bw_team_name% &aa castigat!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNimeni nu a câștigat jocul!");
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lApara-ti patul!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lPatul tau a fost distrus!");
         yml.addDefault(Messages.TEAM_ELIMINATED_CHAT, "\n&f&lTEAM ELIMINAT > %bw_team_color%Echipa %bw_team_name% &ca fost eliminata!\n");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Russian.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Russian.java
@@ -217,6 +217,7 @@ public class Russian extends Language{
                 "&c                          &l3rd Killer &7- %bw_third_format% - %bw_third_kills%", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &aвыиграл игру!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNikto ne vyigral igru!");
         yml.addDefault(Messages.FORMATTING_TEAM_WINNER_FORMAT, "      %bw_team_color%%bw_team_name% &7- %bw_winner_members%");
         yml.addDefault(Messages.FORMATTING_SOLO_WINNER_FORMAT, "                 %bw_team_color%%bw_team_name% &7- %bw_winner_members%");
         yml.addDefault(Messages.MEANING_NOBODY, "Никто");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/SimplifiedChinese.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/SimplifiedChinese.java
@@ -296,6 +296,7 @@ public class SimplifiedChinese extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&l游戏结束！");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&l胜利！");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name%&a赢得了这场游戏！");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&c比赛还没有人获胜！");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Spanish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Spanish.java
@@ -221,6 +221,7 @@ public class Spanish extends Language {
                 "&c                          &l3rd Killer &7- %bw_third_format% - %bw_third_kills%", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &aha ganado el juego!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cNadie ha ganado el juego!");
         yml.addDefault(Messages.MEANING_NOBODY, "Nadie");
         yml.addDefault(Messages.FORMATTING_GENERATOR_TIER1, "I");
         yml.addDefault(Messages.FORMATTING_GENERATOR_TIER2, "II");

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Turkish.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/language/Turkish.java
@@ -297,6 +297,7 @@ public class Turkish extends Language {
         yml.addDefault(Messages.GAME_END_GAME_OVER_PLAYER_TITLE, "&c&lOYUN BİTTİ");
         yml.addDefault(Messages.GAME_END_VICTORY_PLAYER_TITLE, "&6&lGALİBİYET!");
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "%bw_lang_prefix%%bw_team_color%%bw_team_name% &aoyunu kazandı!");
+        yml.addDefault(Messages.GAME_END_NO_WINNERS, "&cOyunu kimse kazanmadı!");
         yml.addDefault(Messages.FORMATTING_EACH_WINNER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_FIRST_KILLER, "%bw_player%");
         yml.addDefault(Messages.GAME_END_SECOND_KILLER, "%bw_player%");


### PR DESCRIPTION
Description of the Change
We now have a message in the chat telling everyone that no one has won the game.
Possible Drawbacks
This means no player wins if both are afk or do not want to fight. Maybe we can implement something where they get teleported to the middle island and have 2 minutes to kill the other.
Verification Process
Tested with 2 players, let the timer run out, and the message showed in chat.
Release Notes
Added: no winner chat message if the time is up and 1 or more players of different teams are still alive