### PR TITLE
HOLOGRAM SYSTEM OPTIMIZATION

### DIFF
--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/IArena.java
@@ -21,9 +21,11 @@
 package com.tomkeuper.bedwars.api.arena;
 
 import com.tomkeuper.bedwars.api.arena.generator.IGenerator;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
 import com.tomkeuper.bedwars.api.arena.team.ITeam;
 import com.tomkeuper.bedwars.api.arena.team.ITeamAssigner;
 import com.tomkeuper.bedwars.api.configuration.ConfigManager;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
 import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.region.Region;
 import com.tomkeuper.bedwars.api.tasks.AnnouncementTask;
@@ -514,6 +516,14 @@ public interface IArena {
      * @return The list of ore generators.
      */
     List<IGenerator> getOreGenerators();
+
+    /**
+     * Get the shop holograms for a specific language ISO code.
+     *
+     * @param iso The ISO code of the language.
+     * @return The list of shop holograms for the specified language.
+     */
+    List<ShopHolo> getShopHolograms(String iso);
 
     /**
      * Get the list of next events to come in the arena.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/generator/IGenHolo.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/generator/IGenHolo.java
@@ -21,6 +21,7 @@
 package com.tomkeuper.bedwars.api.arena.generator;
 
 import org.bukkit.entity.Player;
+import java.util.List;
 
 public interface IGenHolo {
 
@@ -42,7 +43,17 @@ public interface IGenHolo {
     /**
      * Get the player associated with this hologram.
      */
-    Player getPlayer();
+    List<Player> getPlayers();
+
+    /**
+     * Add a player to this hologram.
+     */
+    void addPlayer(Player player);
+
+    /**
+     * Remove a player from this hologram.
+     */
+    void removePlayer(Player player);
 
     /**
      * Get the generator associated with this hologram.
@@ -53,6 +64,11 @@ public interface IGenHolo {
      * Update the hologram.
      */
     void update();
+
+    /**
+     * Update the hologram for a player.
+     */
+    void update(Player player);
 
     /**
      * This must be called when disabling the generator {@link IGenerator#disable()}

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/generator/IGenerator.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/generator/IGenerator.java
@@ -35,9 +35,9 @@ import java.util.List;
 public interface IGenerator {
 
     /**
-     * Get holograms associated to players and generators
+     * Get holograms associated to languages for this generator.
      */
-    HashMap<Player, IGenHolo> getPlayerHolograms();
+    HashMap<String, IGenHolo> getLanguageHolograms();
 
     /**
      * Disable a generator and remove the holograms.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/shop/ShopHolo.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/shop/ShopHolo.java
@@ -22,52 +22,25 @@ package com.tomkeuper.bedwars.api.arena.shop;
 
 import com.tomkeuper.bedwars.api.arena.IArena;
 import com.tomkeuper.bedwars.api.arena.team.ITeam;
-import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
-import lombok.Getter;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ShopHolo {
-    /**
-     * Shop holograms per language <iso, holo></iso,>
-     */
-    @Getter
-    private static HashMap<Player, List<ShopHolo>> shopHolo = new HashMap<>();
 
-    @Getter
     private final IHologram hologram;
-    private final Location l;
     private final IArena a;
     private final ITeam t;
 
-    public ShopHolo(@Nonnull IHologram hologram, Location l, IArena a, ITeam t) {
-        this.l = l;
+    public ShopHolo(@Nonnull IHologram hologram, IArena a, ITeam t) {
         this.hologram = hologram;
         this.a = a;
         this.t = t;
-        shopHolo.putIfAbsent(hologram.getPlayer(), new ArrayList<>());
-        shopHolo.get(hologram.getPlayer()).add(this);
     }
 
-    public void update() {
-        if (l == null) Bukkit.broadcastMessage("LOCATION IS NULL");
-        hologram.getLines().forEach(IHoloLine::reveal);
-    }
-
-    public static void clearForArena(IArena arena) {
-        shopHolo.forEach((p, h) -> h.stream()
-                .filter(holo -> holo.getArena() == arena)
-                .collect(Collectors.toList())
-                .forEach(holo -> holo.getHologram().remove()));
-        shopHolo.entrySet().removeIf(entry -> entry.getValue().stream().anyMatch(holo -> holo.getArena() == arena));
+    public IHologram getHologram() {
+        return hologram;
     }
 
     public IArena getArena() {
@@ -78,28 +51,19 @@ public class ShopHolo {
         return t;
     }
 
-    public static void clearForPlayer(Player p) {
-        if (!shopHolo.containsKey(p)) return;
-        shopHolo.get(p).forEach(h -> h.getHologram().remove());
-        shopHolo.remove(p);
+    public void update() {
+        hologram.update();
     }
 
-    public static void clear() {
-        shopHolo.forEach((p, h) -> h.forEach(holo -> holo.getHologram().remove()));
-        shopHolo.clear();
+    public void update(Player p) {
+        hologram.update(p);
     }
 
-    public static void add(Player p, ShopHolo holo) {
-        if (shopHolo.containsKey(p)) {
-            shopHolo.get(p).add(holo);
-        } else {
-            shopHolo.put(p, new ArrayList<>());
-            shopHolo.get(p).add(holo);
-        }
+    public void clear() {
+        hologram.remove();
     }
 
-    public static List<ShopHolo> getShopHolograms(Player p) {
-        if (!shopHolo.containsKey(p)) shopHolo.put(p, new ArrayList<>());
-        return shopHolo.get(p);
+    public void clearForPlayer(Player p) {
+        hologram.removePlayer(p);
     }
 }

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/team/IBedHolo.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/team/IBedHolo.java
@@ -20,12 +20,8 @@
 
 package com.tomkeuper.bedwars.api.arena.team;
 
-import com.tomkeuper.bedwars.api.configuration.ConfigPath;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
-import com.tomkeuper.bedwars.api.language.Messages;
-import org.bukkit.Bukkit;
-
-import static com.tomkeuper.bedwars.api.language.Language.getMsg;
+import org.bukkit.entity.Player;
 
 public interface IBedHolo {
     /**
@@ -39,14 +35,39 @@ public interface IBedHolo {
     void hide();
 
     /**
+     * Hide the hologram for a specific player.
+     */
+    void hide(Player player);
+
+    /**
      * Destroy the hologram for the bed.
      */
     void destroy();
+
+    /*+
+        * Hide the hologram for a specific player.
+     */
+    void remove(Player player);
 
     /**
      * Show the hologram for the bed.
      */
     void show();
+
+    /**
+     * Show the hologram for a specific player.
+     */
+    void show(Player player);
+
+    /**
+     * Update the hologram for all players.
+     */
+    void update();
+
+    /**
+     * Update the hologram for a specific player.
+     */
+    void update(Player player);
 
     /**
      * Get the main hologram associated with the bed.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/team/ITeam.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/arena/team/ITeam.java
@@ -95,9 +95,11 @@ public interface ITeam {
     Location getBed();
 
     /**
-     * Get the bed hologram of a player
+     * Get the bed hologram of a language
+     *
+     * @param iso target language ISO code.
      */
-    IBedHolo getBedHologram(Player player);
+    IBedHolo getBedHologram(String iso);
 
     /**
      * Set the bed destoryer for the team
@@ -333,6 +335,13 @@ public interface ITeam {
      * @param player target player.
      */
     void destroyBedHolo(Player player);
+
+    /**
+     * Destroy bed hologram for player
+     *
+     * @param iso target language ISO code.
+     */
+    void destroyBedHolo(String iso);
 
     /**
      * Get queued traps for a team.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/configuration/ConfigPath.java
@@ -289,6 +289,7 @@ public class ConfigPath {
 
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_PATH = "performance-settings";
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".rotate-generators";
+    public static final String GENERAL_CONFIGURATION_PERFORMANCE_HOLOGRAM_UPDATE_RATE = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".hologram-update-rate";
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_SPOIL_TNT_PLAYERS = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".spoil-tnt-players";
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_GENERATOR_SPLIT = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".split-island-generator";
 

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/entity/GeneratorHolder.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/entity/GeneratorHolder.java
@@ -24,9 +24,13 @@ import com.tomkeuper.bedwars.api.BedWars;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 
 public class GeneratorHolder {
@@ -36,10 +40,14 @@ public class GeneratorHolder {
     private ArmorStand armorStand;
     @Getter
     private ItemStack helmet;
+    @Getter
+    private World world;
 
     public GeneratorHolder(Location loc, ItemStack helmet) {
         api = Objects.requireNonNull(Bukkit.getServicesManager().getRegistration(BedWars.class)).getProvider();
-        this.armorStand = api.getVersionSupport().createPacketArmorStand(loc);
+        this.world = loc.getWorld();
+        if (world == null) throw new IllegalArgumentException("Location world cannot be null");
+        this.armorStand = api.getVersionSupport().createPacketArmorStand(loc, world.getPlayers());
         this.helmet = helmet;
         if (helmet != null) setHelmet(helmet, true);
         armorStand.setGravity(false);
@@ -51,15 +59,30 @@ public class GeneratorHolder {
     public void setHelmet(ItemStack helmet, boolean update) {
         this.helmet = helmet;
         if (update) {
-            api.getVersionSupport().setGeneratorHolderHelmet(this, helmet);
+            api.getVersionSupport().setGeneratorHolderHelmet(this, helmet, armorStand.getLocation().getWorld().getPlayers());
+        }
+    }
+
+    public void setHelmet(ItemStack helmet, boolean update, Player... players) {
+        this.helmet = helmet;
+        if (update) {
+            api.getVersionSupport().setGeneratorHolderHelmet(this, helmet, Arrays.asList(players));
         }
     }
 
     public void update() {
-        api.getVersionSupport().updatePacketArmorStand(this);
+        api.getVersionSupport().updatePacketArmorStand(this, armorStand.getLocation().getWorld().getPlayers());
+    }
+
+    public void update(Player player) {
+        api.getVersionSupport().updatePacketArmorStand(this, Collections.singletonList(player));
+    }
+
+    public void update(Player... players) {
+        api.getVersionSupport().updatePacketArmorStand(this, Arrays.asList(players));
     }
 
     public void destroy() {
-        api.getVersionSupport().destroyPacketArmorStand(this);
+        api.getVersionSupport().destroyPacketArmorStand(this, world.getPlayers());
     }
 }

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/entity/GeneratorHolder.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/entity/GeneratorHolder.java
@@ -58,16 +58,8 @@ public class GeneratorHolder {
 
     public void setHelmet(ItemStack helmet, boolean update) {
         this.helmet = helmet;
-        if (update) {
-            api.getVersionSupport().setGeneratorHolderHelmet(this, helmet, armorStand.getLocation().getWorld().getPlayers());
-        }
-    }
-
-    public void setHelmet(ItemStack helmet, boolean update, Player... players) {
-        this.helmet = helmet;
-        if (update) {
-            api.getVersionSupport().setGeneratorHolderHelmet(this, helmet, Arrays.asList(players));
-        }
+        updateEquipment();
+        if (update) update();
     }
 
     public void update() {
@@ -84,5 +76,9 @@ public class GeneratorHolder {
 
     public void destroy() {
         api.getVersionSupport().destroyPacketArmorStand(this, world.getPlayers());
+    }
+    
+    private void updateEquipment() {
+        api.getVersionSupport().updatePacketArmorStandEquipment(this);
     }
 }

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/IHologramManager.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/IHologramManager.java
@@ -25,6 +25,8 @@ import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import java.util.List;
+
 public interface IHologramManager {
 
     /**
@@ -36,6 +38,16 @@ public interface IHologramManager {
      * @return the hologram
      */
     IHologram createHologram(Player p, Location location, String... lines);
+
+    /**
+     * Create a hologram with the given lines at the given location.
+     *
+     * @param players - the player to create the hologram for
+     * @param location - the location to create the hologram at
+     * @param lines - the lines to create the hologram from
+     * @return the hologram
+     */
+    IHologram createHologram(List<Player> players, Location location, String... lines);
 
     /**
      * Create a hologram with the given lines at the given location.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/containers/IHoloLine.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/containers/IHoloLine.java
@@ -20,6 +20,8 @@
 
 package com.tomkeuper.bedwars.api.hologram.containers;
 
+import org.bukkit.entity.Player;
+
 public interface IHoloLine {
 
     /**
@@ -39,6 +41,11 @@ public interface IHoloLine {
      */
     void update();
 
+    /**
+     * Update the hologram line for a player.
+     * @param player - the player
+     */
+    void update(Player player);
 
     /**
      * Check if the hologram line is destroyed.
@@ -72,10 +79,23 @@ public interface IHoloLine {
     void reveal();
 
     /**
+     * Reveals the hologram line for a player if the line has disappeared
+     * been removed by the server or another plugin
+     * @param player - the player
+     */
+    void reveal(Player player);
+
+    /**
      * Remove the hologram line but keeping the line object
      * in its bounded hologram
      */
     void remove();
+
+    /**
+     * Remove the hologram line for a player but keeping the line object
+     * @param player - the player
+     */
+    void remove(Player player);
 
     /**
      * Destroy the hologram line and also remove it

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/containers/IHologram.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/hologram/containers/IHologram.java
@@ -31,7 +31,18 @@ public interface IHologram {
      * Get the player this hologram is bounded to.
      * @return the player
      */
-    Player getPlayer();
+    List<Player> getPlayers();
+
+    /**
+     * Add a player to this hologram.
+     * @param player - the player you want to add
+     */
+    void addPlayer(Player player);
+
+    /**
+     * Remove a player from this hologram.
+     */
+    void removePlayer(Player player);
 
     /**
      * Add a line to the hologram.
@@ -67,6 +78,12 @@ public interface IHologram {
      * Update the hologram.
      */
     void update();
+
+    /**
+     * Update the hologram for a specific player.
+     * @param player - the player to update the hologram for
+     */
+    void update(Player player);
 
     /**
      * Show the hologram.

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
@@ -519,5 +519,5 @@ public abstract class VersionSupport {
 
     public abstract void updatePacketArmorStand(GeneratorHolder generatorHolder, List<Player> players);
 
-    public abstract void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet, List<Player> players);
+    public abstract void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder);
 }

--- a/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
+++ b/bedwars-api/src/main/java/com/tomkeuper/bedwars/api/server/VersionSupport.java
@@ -501,19 +501,23 @@ public abstract class VersionSupport {
 
     public abstract void playVillagerEffect(Player player, Location location);
 
-    public abstract void updatePacketArmorStand(GeneratorHolder generatorHolder);
-
-    public abstract void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet);
-
     public abstract IHologram createHologram(Player p, Location location, String... lines);
 
     public abstract IHologram createHologram(Player p, Location location, IHoloLine... lines);
+
+    public abstract IHologram createHologram(List<Player> players, Location location, String... lines);
+
+    public abstract IHologram createHologram(List<Player> players, Location location, IHoloLine... lines);
 
     public abstract IHoloLine lineFromText(String text, @Nonnull IHologram hologram);
 
     public abstract IGeneratorAnimation createDefaultGeneratorAnimation(ArmorStand armorStand);
 
-    public abstract void destroyPacketArmorStand(GeneratorHolder generatorHolder);
+    public abstract void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players);
 
-    public abstract ArmorStand createPacketArmorStand(@Nonnull Location loc);
+    public abstract ArmorStand createPacketArmorStand(@Nonnull Location loc, List<Player> players);
+
+    public abstract void updatePacketArmorStand(GeneratorHolder generatorHolder, List<Player> players);
+
+    public abstract void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet, List<Player> players);
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.economy.IEconomy;
 import com.tomkeuper.bedwars.api.items.handlers.IPermanentItem;
 import com.tomkeuper.bedwars.api.items.handlers.IPermanentItemHandler;
 import com.tomkeuper.bedwars.arena.feature.ResourceChestFeature;
+import com.tomkeuper.bedwars.arena.tasks.HologramTask;
 import com.tomkeuper.bedwars.handlers.items.LobbyItem;
 import com.tomkeuper.bedwars.api.hologram.IHologramManager;
 import com.tomkeuper.bedwars.api.language.Language;
@@ -454,6 +455,8 @@ public class BedWars extends JavaPlugin {
             //new OneTick().runTaskTimer(this, 120, 1);
             Bukkit.getScheduler().runTaskTimer(this, new OneTick(), 120, 1);
         }
+
+        Bukkit.getScheduler().runTaskLater(this, new HologramTask(), config.getInt(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_HOLOGRAM_UPDATE_RATE));
 
         /* Register NMS entities */
         nms.registerEntities();

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -970,10 +970,8 @@ public class Arena implements IArena {
 
         // Clear shop holo's for leaving players.
         String iso = Language.getPlayerLanguage(p).getIso();
-        List<ShopHolo> holos = shopHolosIso.get(iso);
-        for (ShopHolo holo : holos) {
-            holo.clearForPlayer(p);
-        }
+        List<ShopHolo> holos = shopHolosIso.getOrDefault(iso, Collections.emptyList());
+        for (ShopHolo holo : holos) holo.clearForPlayer(p);
 
         /**
          * Below is *only* executed if serverType != BUNGEE
@@ -1115,10 +1113,8 @@ public class Arena implements IArena {
 
         // Clear shop holo's for leaving players.
         String iso = Language.getPlayerLanguage(p).getIso();
-        List<ShopHolo> holos = shopHolosIso.get(iso);
-        for (ShopHolo holo : holos) {
-            holo.clearForPlayer(p);
-        }
+        List<ShopHolo> holos = shopHolosIso.getOrDefault(iso, Collections.emptyList());
+        for (ShopHolo holo : holos) holo.clearForPlayer(p);
 
         for (PotionEffect pf : p.getActivePotionEffects()) {
             p.removePotionEffect(pf.getType());

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -184,6 +184,9 @@ public class Arena implements IArena {
     /* ARENA GENERATORS */
     private List<IGenerator> oreGenerators = new ArrayList<>();
 
+    /* SHOP HOLOGRAMS */
+    private HashMap<String, List<ShopHolo>> shopHolosIso = new HashMap<>();
+
     private PerMinuteTask perMinuteTask;
 
     private MoneyPerMinuteTask moneyperMinuteTask;
@@ -966,7 +969,11 @@ public class Arena implements IArena {
         }
 
         // Clear shop holo's for leaving players.
-        ShopHolo.clearForPlayer(p);
+        String iso = Language.getPlayerLanguage(p).getIso();
+        List<ShopHolo> holos = shopHolosIso.get(iso);
+        for (ShopHolo holo : holos) {
+            holo.clearForPlayer(p);
+        }
 
         /**
          * Below is *only* executed if serverType != BUNGEE
@@ -1107,7 +1114,11 @@ public class Arena implements IArena {
         }
 
         // Clear shop holo's for leaving players.
-        ShopHolo.clearForPlayer(p);
+        String iso = Language.getPlayerLanguage(p).getIso();
+        List<ShopHolo> holos = shopHolosIso.get(iso);
+        for (ShopHolo holo : holos) {
+            holo.clearForPlayer(p);
+        }
 
         for (PotionEffect pf : p.getActivePotionEffects()) {
             p.removePotionEffect(pf.getType());
@@ -2322,6 +2333,11 @@ public class Arena implements IArena {
      */
     public List<IGenerator> getOreGenerators() {
         return oreGenerators;
+    }
+
+    @Override
+    public List<ShopHolo> getShopHolograms(String iso) {
+        return shopHolosIso.get(iso);
     }
 
     /**

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/OreGenerator.java
@@ -45,7 +45,6 @@ import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,14 +70,9 @@ public class OreGenerator implements IGenerator {
     private List<IGeneratorAnimation> animations;
     private int dropID = 0;
     private ITeam bwt;
-    private boolean hologram = true;
+    public HashMap<String, IGenHolo> hologramLanguages = new HashMap<>();
+    private boolean hologramEnabled = true;
     boolean disabled = false;
-
-    /**
-     * Generator holograms per language <iso, holo></iso,>
-     */
-    public HashMap<Player, IGenHolo> holograms = new HashMap<>();
-
     private GeneratorHolder item;
     public boolean stack = BedWars.getGeneratorsCfg().getBoolean(ConfigPath.GENERATOR_STACK_ITEMS);
 
@@ -94,7 +88,7 @@ public class OreGenerator implements IGenerator {
         this.arena = arena;
         this.bwt = bwt;
         this.type = type;
-        this.hologram = hologram;
+        this.hologramEnabled = hologram;
         loadDefaults();
         BedWars.debug("Initializing new generator at: " + location + " - " + type + " - " + (bwt == null ? "NOTEAM" : bwt.getName()));
 
@@ -125,9 +119,10 @@ public class OreGenerator implements IGenerator {
                             "Default." + ConfigPath.GENERATOR_DIAMOND_TIER_III_SPAWN_LIMIT : arena.getGroup() + "." + ConfigPath.GENERATOR_DIAMOND_TIER_III_SPAWN_LIMIT);
                 }
                 ore = new ItemStack(Material.DIAMOND);
-                for (IGenHolo e : holograms.values()) {
-                    e.setTierName(Language.getLang(e.getIso()).m(Messages.GENERATOR_HOLOGRAM_TIER).replace("%bw_tier%", Language.getLang(e.getIso())
-                            .m(upgradeStage == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)));
+                for (IGenHolo e : hologramLanguages.values()) {
+                    if (e.getGenerator().getType() != GeneratorType.DIAMOND) continue;
+                    e.setTierName(Language.getLang(e.getIso()).m(Messages.GENERATOR_HOLOGRAM_TIER).replace("%bw_tier%",
+                            Language.getLang(e.getIso()).m(upgradeStage == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)));
                 }
                 break;
             case EMERALD:
@@ -148,7 +143,8 @@ public class OreGenerator implements IGenerator {
                             "Default." + ConfigPath.GENERATOR_EMERALD_TIER_III_SPAWN_LIMIT : arena.getGroup() + "." + ConfigPath.GENERATOR_EMERALD_TIER_III_SPAWN_LIMIT);
                 }
                 ore = new ItemStack(Material.EMERALD);
-                for (IGenHolo e : holograms.values()) {
+                for (IGenHolo e : hologramLanguages.values()) {
+                    if (e.getGenerator().getType() != GeneratorType.EMERALD) continue;
                     e.setTierName(Language.getLang(e.getIso()).m(Messages.GENERATOR_HOLOGRAM_TIER).replace("%bw_tier%",
                             Language.getLang(e.getIso()).m(upgradeStage == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)));
                 }
@@ -193,13 +189,12 @@ public class OreGenerator implements IGenerator {
         }
         lastSpawn--;
 
-        if ((getType() == GeneratorType.EMERALD || getType() == GeneratorType.DIAMOND) && hologram) {
-            for (Player p : arena.getWorld().getPlayers()) {
-                IGenHolo e = holograms.get(p);
-                if (e == null) holograms.put(p, new HoloGram(p));
-                e = holograms.get(p);
+        if ((getType() == GeneratorType.EMERALD || getType() == GeneratorType.DIAMOND) && hologramEnabled) {
+            for (String iso : hologramLanguages.keySet()) {
+                IGenHolo e = hologramLanguages.get(iso);
+                if (e.getGenerator().getType() != getType()) continue;
 
-                e.setTimerName(Language.getLang(e.getIso()).m(Messages.GENERATOR_HOLOGRAM_TIMER).replace("%bw_seconds%", String.valueOf((int) Math.ceil(lastSpawn/speedMultiplier))));
+                e.setTimerName(Language.getLang(iso).m(Messages.GENERATOR_HOLOGRAM_TIMER).replace("%bw_seconds%", String.valueOf((int) Math.ceil(lastSpawn/speedMultiplier))));
             }
         }
     }
@@ -240,21 +235,14 @@ public class OreGenerator implements IGenerator {
         animations.add(animation);
     }
 
-    @Override
-    public HashMap<Player, IGenHolo> getPlayerHolograms() {
-        return holograms;
-    }
-
     @SuppressWarnings("WeakerAccess")
     public class HoloGram implements IGenHolo {
         String iso;
         IHologram hologram;
         IHoloLine tier, timer, name;
-        Player p;
 
-        public HoloGram(Player p) {
-            this.p = p;
-            this.iso = Language.getPlayerLanguage(p).getIso();
+        public HoloGram(List<Player> players, String iso) {
+            this.iso = iso;
 
             if (getType() != GeneratorType.EMERALD && getType() != GeneratorType.DIAMOND) return;
 
@@ -264,7 +252,7 @@ public class OreGenerator implements IGenerator {
                     .replace("%bw_seconds%", String.valueOf(lastSpawn));
             String nameText = Language.getLang(iso).m(getOre().getType() == Material.DIAMOND ? Messages.GENERATOR_HOLOGRAM_TYPE_DIAMOND
                     : Messages.GENERATOR_HOLOGRAM_TYPE_EMERALD);
-            hologram = BedWars.getAPI().getHologramsUtil().createHologram(p, location.clone().add(0, 0.5, 0), tierText, nameText, timerText);
+            hologram = BedWars.getAPI().getHologramsUtil().createHologram(players, location.clone().add(0, 0.5, 0), tierText, nameText, timerText);
             hologram.setGap(0.3);
 
             this.timer = hologram.getLine(0);
@@ -288,8 +276,18 @@ public class OreGenerator implements IGenerator {
         }
 
         @Override
-        public Player getPlayer() {
-            return p;
+        public List<Player> getPlayers() {
+            return hologram.getPlayers();
+        }
+
+        @Override
+        public void addPlayer(Player player) {
+            hologram.addPlayer(player);
+        }
+
+        @Override
+        public void removePlayer(Player player) {
+            hologram.removePlayer(player);
         }
 
         @Override
@@ -300,6 +298,11 @@ public class OreGenerator implements IGenerator {
         @Override
         public void update() {
             hologram.getLines().forEach(IHoloLine::reveal);
+        }
+
+        @Override
+        public void update(Player player) {
+            hologram.getLines().forEach(line -> line.reveal(player));
         }
 
         @Override
@@ -344,17 +347,22 @@ public class OreGenerator implements IGenerator {
     }
 
     @Override
+    public HashMap<String, IGenHolo> getLanguageHolograms() {
+        return hologramLanguages;
+    }
+
+    @Override
     public void disable() {
         if (getType() == GeneratorType.DIAMOND || getType() == GeneratorType.EMERALD) {
             rotation.remove(this);
-            for (IGenHolo a : holograms.values()) {
-                a.destroy();
+            for (IGenHolo item : hologramLanguages.values()) {
+                item.destroy();
             }
             if (item != null) {
                 item.destroy();
                 item = null;
             }
-            holograms.clear();
+            hologramLanguages.clear();
         }
         disabled = true;
     }
@@ -369,15 +377,24 @@ public class OreGenerator implements IGenerator {
 
     @Override
     public void updateHolograms(Player p) {
-        if (!hologram) return;
+        if (!hologramEnabled) return;
         if (getType() != GeneratorType.EMERALD && getType() != GeneratorType.DIAMOND) return;
         if (!arena.getWorld().getPlayers().contains(p)) return;
 
-        IGenHolo h = holograms.get(p);
-        if (h == null && hologram) holograms.put(p, new HoloGram(p));
-        h = holograms.get(p);
+        for (Language lang : Language.getLanguages()) {
+            List<Player> playersToAdd = new ArrayList<>();
+            if (Language.getPlayerLanguage(p).getIso().equals(lang.getIso())) {
+                playersToAdd.add(p);
+            }
 
-        h.update();
+            if (!hologramLanguages.containsKey(lang.getIso())) {
+                IGenHolo holo = hologramLanguages.put(lang.getIso(), new HoloGram(playersToAdd, lang.getIso()));
+            }
+        }
+
+        for (IGenHolo hg : hologramLanguages.values()) {
+            hg.update();
+        }
     }
 
     @Override
@@ -385,14 +402,22 @@ public class OreGenerator implements IGenerator {
         //loadDefaults(false);
         //if (getType() == GeneratorType.EMERALD || getType() == GeneratorType.DIAMOND) {
         rotation.add(this);
-        if (hologram) {
-            for (Player p : arena.getWorld().getPlayers()) {
-                IGenHolo h = holograms.get(p);
-                if (h == null) {
-                    holograms.put(p, new HoloGram(p));
+        if (hologramEnabled) {
+            for (Language lang : Language.getLanguages()) {
+                List<Player> playersToAdd = new ArrayList<>();
+                for (Player p : arena.getWorld().getPlayers()) {
+                    if (Language.getPlayerLanguage(p).getIso().equals(lang.getIso())) {
+                        playersToAdd.add(p);
+                    }
                 }
+
+                if (!hologramLanguages.containsKey(lang.getIso())) {
+                    hologramLanguages.put(lang.getIso(), new HoloGram(playersToAdd, lang.getIso()));
+                }
+
             }
-            for (IGenHolo hg : holograms.values()) {
+
+            for (IGenHolo hg : hologramLanguages.values()) {
                 hg.update();
             }
         }
@@ -502,7 +527,7 @@ public class OreGenerator implements IGenerator {
 
     @Override
     public boolean isHologramEnabled() {
-        return hologram;
+        return hologramEnabled;
     }
 
     @Override
@@ -516,7 +541,7 @@ public class OreGenerator implements IGenerator {
         arena = null;
         ore = null;
         bwt = null;
-        holograms = null;
+        hologramLanguages = null;
         item = null;
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameRestartingTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameRestartingTask.java
@@ -25,6 +25,7 @@ import com.tomkeuper.bedwars.api.arena.generator.IGenerator;
 import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
 import com.tomkeuper.bedwars.api.arena.team.ITeam;
 import com.tomkeuper.bedwars.api.configuration.ConfigPath;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.server.ServerType;
 import com.tomkeuper.bedwars.api.tasks.RestartingTask;
 import com.tomkeuper.bedwars.arena.Arena;
@@ -38,6 +39,7 @@ import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GameRestartingTask implements Runnable, RestartingTask {
 
@@ -87,7 +89,15 @@ public class GameRestartingTask implements Runnable, RestartingTask {
                 getArena().removeSpectator(on, BedWars.getServerType() == ServerType.BUNGEE, true);
             }
         } else if (restarting == 4) {
-            ShopHolo.clearForArena(getArena());
+            for (Language lang : Language.getLanguages()) {
+                List<ShopHolo> holos = getArena().getShopHolograms(lang.getIso());
+                for (ShopHolo holo : holos) {
+                    if (holo != null) {
+                        holo.clear();
+                    }
+                }
+            }
+
             for (Entity e : getArena().getWorld().getEntities()) {
                 if (e.getType() == EntityType.PLAYER) {
                     Player p = (Player) e;

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameRestartingTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameRestartingTask.java
@@ -91,9 +91,9 @@ public class GameRestartingTask implements Runnable, RestartingTask {
         } else if (restarting == 4) {
             for (Language lang : Language.getLanguages()) {
                 List<ShopHolo> holos = getArena().getShopHolograms(lang.getIso());
-                for (ShopHolo holo : holos) {
-                    if (holo != null) {
-                        holo.clear();
+                if (holos != null) {
+                    for (ShopHolo holo : holos) {
+                        if (holo != null) holo.clear();
                     }
                 }
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -1,0 +1,60 @@
+package com.tomkeuper.bedwars.arena.tasks;
+
+import com.tomkeuper.bedwars.BedWars;
+import com.tomkeuper.bedwars.api.arena.GameState;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.arena.generator.GeneratorType;
+import com.tomkeuper.bedwars.api.arena.generator.IGenHolo;
+import com.tomkeuper.bedwars.api.arena.generator.IGenerator;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.arena.Arena;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+public class HologramTask implements Runnable {
+
+    @Override
+    public void run() {
+        for (IArena a : Arena.getArenas()) {
+            World world = a.getWorld();
+            if (world == null) continue;
+            if (a.getStatus() != GameState.playing) continue;
+
+            if (world.getPlayers().isEmpty()) continue;
+
+            for (Player p : world.getPlayers()) {
+                String iso = Language.getPlayerLanguage(p).getIso();
+                Location pLoc = p.getLocation();
+                List<ShopHolo> shopHolos = a.getShopHolograms(iso);
+                for (ShopHolo shopHolo : shopHolos) {
+                    IHologram hologram = shopHolo.getHologram();
+                    Location holoLoc = hologram.getLocation();
+                    double distance = pLoc.distance(holoLoc);
+                    if (distance <= BedWars.hologramUpdateDistance) continue;
+                    hologram.getLines().forEach(line -> line.reveal(p));
+                }
+            }
+
+            List<IGenerator> generators = a.getOreGenerators();
+            for (IGenerator generator : generators) {
+                GeneratorType type = generator.getType();
+                if (type != GeneratorType.EMERALD && type !=  GeneratorType.DIAMOND) continue;
+                Location genLoc = generator.getLocation();
+                for (Player p : world.getPlayers()) {
+                    String iso = Language.getPlayerLanguage(p).getIso();
+                    IGenHolo holo = generator.getLanguageHolograms().get(iso);
+                    Location pLoc = p.getLocation();
+                    double distance = pLoc.distance(genLoc);
+                    if (distance <= BedWars.hologramUpdateDistance) continue;
+                    holo.update(p);
+                    generator.getHologramHolder().update(p);
+                }
+            }
+        }
+    }
+}

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -7,9 +7,12 @@ import com.tomkeuper.bedwars.api.arena.generator.GeneratorType;
 import com.tomkeuper.bedwars.api.arena.generator.IGenHolo;
 import com.tomkeuper.bedwars.api.arena.generator.IGenerator;
 import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.arena.team.IBedHolo;
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
 import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.arena.Arena;
+import com.tomkeuper.bedwars.arena.team.BedWarsTeam;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -37,6 +40,21 @@ public class HologramTask implements Runnable {
                     double distance = pLoc.distance(holoLoc);
                     if (distance <= BedWars.hologramUpdateDistance) continue;
                     hologram.getLines().forEach(line -> line.reveal(p));
+                }
+            }
+
+            for (ITeam team : a.getTeams()) {
+                if (!(team instanceof BedWarsTeam)) continue;
+                for (Language lang : Language.getLanguages()) {
+                    String iso = lang.getIso();
+                    IBedHolo bedHolo = ((BedWarsTeam) team).getBedHologram(iso);
+                    Location bedLoc = bedHolo.getHologram().getLocation();
+                    for (Player p : world.getPlayers()) {
+                        Location pLoc = p.getLocation();
+                        double distance = pLoc.distance(bedLoc);
+                        if (distance <= BedWars.hologramUpdateDistance) continue;
+                        bedHolo.update(p);
+                    }
                 }
             }
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -9,6 +9,7 @@ import com.tomkeuper.bedwars.api.arena.generator.IGenerator;
 import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
 import com.tomkeuper.bedwars.api.arena.team.IBedHolo;
 import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
 import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.arena.Arena;
@@ -39,22 +40,20 @@ public class HologramTask implements Runnable {
                     Location holoLoc = hologram.getLocation();
                     double distance = pLoc.distance(holoLoc);
                     if (distance <= BedWars.hologramUpdateDistance) continue;
-                    hologram.getLines().forEach(line -> line.reveal(p));
+                    shopHolo.update(p);
                 }
             }
 
             for (ITeam team : a.getTeams()) {
                 if (!(team instanceof BedWarsTeam)) continue;
-                for (Language lang : Language.getLanguages()) {
-                    String iso = lang.getIso();
+                for (Player p : world.getPlayers()) {
+                    String iso = Language.getPlayerLanguage(p).getIso();
                     IBedHolo bedHolo = ((BedWarsTeam) team).getBedHologram(iso);
                     Location bedLoc = bedHolo.getHologram().getLocation();
-                    for (Player p : world.getPlayers()) {
-                        Location pLoc = p.getLocation();
-                        double distance = pLoc.distance(bedLoc);
-                        if (distance <= BedWars.hologramUpdateDistance) continue;
-                        bedHolo.update(p);
-                    }
+                    Location pLoc = p.getLocation();
+                    double distance = pLoc.distance(bedLoc);
+                    if (distance <= BedWars.hologramUpdateDistance) continue;
+                    bedHolo.update(p);
                 }
             }
 
@@ -66,11 +65,12 @@ public class HologramTask implements Runnable {
                 for (Player p : world.getPlayers()) {
                     String iso = Language.getPlayerLanguage(p).getIso();
                     IGenHolo holo = generator.getLanguageHolograms().get(iso);
+                    GeneratorHolder holder = generator.getHologramHolder();
                     Location pLoc = p.getLocation();
                     double distance = pLoc.distance(genLoc);
                     if (distance <= BedWars.hologramUpdateDistance) continue;
                     holo.update(p);
-                    generator.getHologramHolder().update(p);
+                    holder.update(p);
                 }
             }
         }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -32,7 +32,7 @@ public class HologramTask implements Runnable {
             if (world.getPlayers().isEmpty()) continue;
 
             for (Player p : world.getPlayers()) {
-                String iso = Language.getPlayerLanguage(p).getIso();    
+                String iso = Language.getPlayerLanguage(p).getIso();
                 Location pLoc = p.getLocation();
                 List<ShopHolo> shopHolos = a.getShopHolograms(iso);
                 for (ShopHolo shopHolo : shopHolos) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -32,7 +32,7 @@ public class HologramTask implements Runnable {
             if (world.getPlayers().isEmpty()) continue;
 
             for (Player p : world.getPlayers()) {
-                String iso = Language.getPlayerLanguage(p).getIso();
+                String iso = Language.getPlayerLanguage(p).getIso();    
                 Location pLoc = p.getLocation();
                 List<ShopHolo> shopHolos = a.getShopHolograms(iso);
                 for (ShopHolo shopHolo : shopHolos) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
@@ -478,20 +478,30 @@ public class BedWarsTeam implements ITeam {
             //
         }, 10L);
 
-        if (ShopHolo.getShopHolograms(p) != null) {
-            List<ITeam> teams = ShopHolo.getShopHolograms(p).stream().map(ShopHolo::getTeam).collect(Collectors.toList());
-            if (teams.contains(this)) {
-                ShopHolo h = ShopHolo.getShopHolograms(p).stream().filter(sh -> sh.getTeam().equals(this)).findFirst().orElse(null);
-                if (h != null) h.update();
-            } else {
+        boolean found = false;
+        for (Language lang : Language.getLanguages()) {
+            String iso = lang.getIso();
+            List<ShopHolo> holograms = arena.getShopHolograms(iso);
+            if (holograms == null) continue;
+            if (holograms.isEmpty()) continue;
+            for (ShopHolo h : holograms) {
+                if (h == null) continue;
+                if (h.getTeam().equals(this)) {
+                    h.update(p);
+                    found = true;
+                }
+            }
+
+            if (!found) {
                 nms.spawnShopHologram(arena.getConfig().getArenaLoc("Team." + getName() + ".Upgrade"), (arena.getMaxInTeam() > 1 ? Messages.NPC_NAME_TEAM_UPGRADES.replace("%group%", arena.getGroup()) : Messages.NPC_NAME_SOLO_UPGRADES.replace("%group%", arena.getGroup())), Collections.singletonList(p), arena, this);
                 nms.spawnShopHologram(arena.getConfig().getArenaLoc("Team." + getName() + ".Shop"), (arena.getMaxInTeam() > 1 ? Messages.NPC_NAME_TEAM_SHOP.replace("%group%", arena.getGroup()) : Messages.NPC_NAME_SOLO_SHOP.replace("%group%", arena.getGroup())), Collections.singletonList(p), arena, this);
             }
         }
 
         for (IGenerator gen : getArena().getOreGenerators()) {
-            IGenHolo h = gen.getPlayerHolograms().get(p);
-            if (h != null) h.update();
+            String iso = Language.getPlayerLanguage(p).getIso();
+            IGenHolo h = gen.getLanguageHolograms().get(iso);
+            if (h != null) h.update(p);
         }
         if (getBedHologram(p) != null) getBedHologram(p).show();
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
@@ -581,6 +581,7 @@ public class BedWarsTeam implements ITeam {
             line.remove();
         }
 
+        @Override
         public void hide(Player player) {
             if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
             hidden = true;

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
@@ -116,7 +116,7 @@ public class BedWarsTeam implements ITeam {
 
     // Used for show/ hide bed hologram
     @Getter
-    private final HashMap<UUID, BedHolo> beds = new HashMap<>();
+    private final HashMap<String, BedHolo> beds = new HashMap<>();
 
     // Queued traps
     private final LinkedList<EnemyBaseEnterTrap> enemyBaseEnterTraps = new LinkedList<>();
@@ -165,13 +165,15 @@ public class BedWarsTeam implements ITeam {
         if (players == null) return;
         for (Player p : players) {
             if (p == null) continue;
+            String iso = Language.getPlayerLanguage(p).getIso();
             members.removeIf(player -> player.getUniqueId().equals(p.getUniqueId()));
             members.add(p);
 
             membersCache.removeIf(player -> player.getUniqueId().equals(p.getUniqueId()));
             membersCache.add(p);
-
-            new BedHolo(p, getArena());
+            BedHolo holo = beds.get(iso);
+            if (holo == null) holo = new BedHolo(iso, arena, this);
+            else holo.show();
         }
     }
 
@@ -503,7 +505,9 @@ public class BedWarsTeam implements ITeam {
             IGenHolo h = gen.getLanguageHolograms().get(iso);
             if (h != null) h.update(p);
         }
-        if (getBedHologram(p) != null) getBedHologram(p).show();
+        String iso = Language.getPlayerLanguage(p).getIso();
+        IBedHolo bedHolo = getBedHologram(iso);
+        if (bedHolo != null) bedHolo.show(p);
 
         Sounds.playSound("player-re-spawn", p);
     }
@@ -539,33 +543,36 @@ public class BedWarsTeam implements ITeam {
      */
     @SuppressWarnings("WeakerAccess")
     public class BedHolo implements IBedHolo {
+
+        private final String iso;
+
+        private final ITeam team;
         private IHologram h;
         private IHoloLine line;
-        private final UUID p;
         @Getter
         private Arena arena;
         @Getter
         private boolean hidden = false;
 
-        public BedHolo(@NotNull Player p, Arena arena) {
-            this.p = p.getUniqueId();
+        public BedHolo(@NotNull String iso, Arena arena, ITeam team) {
+            this.iso = iso;
             this.arena = arena;
+            this.team = team;
             create();
         }
 
         public void create() {
             if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
             // Note: Getting location after retrieving the block will make sure the hologram location will always be relative to the block instead of the actual config entry.
-            h = BedWars.hologramManager.createHologram(Bukkit.getPlayer(p), getBed().getBlock().getLocation().clone().add(0.5, -0.3, 0.5), "");
+            h = BedWars.hologramManager.createHologram(arena.getPlayers(), getBed().getBlock().getLocation().clone().add(0.5, -0.3, 0.5), "");
             line = h.getLine(0);
 
+            Language lang = Language.getLang(iso);
             if (isBedDestroyed()) {
-                line.setText(getMsg(Bukkit.getPlayer(p), Messages.BED_HOLOGRAM_DESTROYED));
+                line.setText(lang.m(Messages.BED_HOLOGRAM_DESTROYED));
                 bedDestroyed = true;
-            } else {
-                line.setText(getMsg(Bukkit.getPlayer(p), Messages.BED_HOLOGRAM_DEFEND));
-            }
-            beds.put(p, this);
+            } else line.setText(lang.m(Messages.BED_HOLOGRAM_DEFEND));
+            beds.put(iso, this);
         }
 
         public void hide() {
@@ -574,21 +581,53 @@ public class BedWarsTeam implements ITeam {
             line.remove();
         }
 
+        public void hide(Player player) {
+            if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
+            hidden = true;
+            line.remove(player);
+        }
+
         public void destroy() {
             if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
             h.remove();
-            beds.remove(p);
+            beds.remove(iso);
+        }
+
+        @Override
+        public void remove(Player player) {
+            if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
+            h.removePlayer(player);
         }
 
         public void show() {
             if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
             hidden = false;
             line.reveal();
-            if (isBedDestroyed()) {
-                line.setText(getMsg(Bukkit.getPlayer(p), Messages.BED_HOLOGRAM_DESTROYED));
-            } else {
-                line.setText(getMsg(Bukkit.getPlayer(p), Messages.BED_HOLOGRAM_DEFEND));
-            }
+
+            Language lang = Language.getLang(iso);
+            if (isBedDestroyed()) line.setText(lang.m(Messages.BED_HOLOGRAM_DESTROYED));
+            else line.setText(lang.m(Messages.BED_HOLOGRAM_DEFEND));
+        }
+
+        @Override
+        public void show(Player player) {
+            if (!arena.getConfig().getBoolean(ConfigPath.ARENA_USE_BED_HOLO)) return;
+            hidden = false;
+            line.reveal(player);
+
+            Language lang = Language.getLang(iso);
+            if (isBedDestroyed()) line.setText(lang.m(Messages.BED_HOLOGRAM_DESTROYED));
+            else line.setText(lang.m(Messages.BED_HOLOGRAM_DEFEND));
+        }
+
+        @Override
+        public void update() {
+            h.update();
+        }
+
+        @Override
+        public void update(Player player) {
+            h.update(player);
         }
 
         public IHologram getHologram() {
@@ -596,7 +635,7 @@ public class BedWarsTeam implements ITeam {
         }
 
         public boolean isBedDestroyed()  {
-            return arena.getTeam(Bukkit.getPlayer(p)).isBedDestroyed();
+            return team.isBedDestroyed();
         }
 
     }
@@ -741,8 +780,8 @@ public class BedWarsTeam implements ITeam {
     }
 
     @Override
-    public BedHolo getBedHologram(@NotNull Player p) {
-        return beds.get(p.getUniqueId());
+    public BedHolo getBedHologram(@NotNull String iso) {
+        return beds.get(iso);
     }
 
     /**
@@ -821,7 +860,15 @@ public class BedWarsTeam implements ITeam {
 
     @Override
     public void destroyBedHolo(@NotNull Player player) {
-        if (getBeds().get(player.getUniqueId()) != null) getBeds().get(player.getUniqueId()).destroy();
+        String iso = Language.getPlayerLanguage(player).getIso();
+        IBedHolo bedHolo = getBedHologram(iso);
+        if (bedHolo != null) bedHolo.remove(player);
+    }
+
+    @Override
+    public void destroyBedHolo(String iso) {
+        IBedHolo bedHolo = getBedHologram(iso);
+        if (bedHolo != null) bedHolo.destroy();
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -167,7 +167,7 @@ public class MainConfig extends ConfigManager {
         //
 
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN, true);
-        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_HOLOGRAM_UPDATE_RATE, 10);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_HOLOGRAM_UPDATE_RATE, 5);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_SPOIL_TNT_PLAYERS, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_GENERATOR_SPLIT, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_PAPER_FEATURES, true);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/MainConfig.java
@@ -167,6 +167,7 @@ public class MainConfig extends ConfigManager {
         //
 
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN, true);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_HOLOGRAM_UPDATE_RATE, 10);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_SPOIL_TNT_PLAYERS, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_GENERATOR_SPLIT, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_PAPER_FEATURES, true);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/hologram/HologramManager.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/hologram/HologramManager.java
@@ -27,6 +27,8 @@ import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import java.util.List;
+
 public class HologramManager implements IHologramManager {
 
     @Override
@@ -35,9 +37,16 @@ public class HologramManager implements IHologramManager {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        return BedWars.nms.createHologram(players, location, lines);
+    }
+
+    @Override
     public IHologram createHologram(Player p, Location location, IHoloLine... lines) {
         return BedWars.nms.createHologram(p, location, lines);
     }
+
+
 
     @Override
     public IHoloLine lineFromText(String text, IHologram hologram) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
@@ -688,22 +688,6 @@ public class DamageDeathMove implements Listener {
                     if (player.getLocation().getBlockY() <= a.getYKillHeight()) {
                         BedWars.nms.voidKill(player);
                     }
-                    for (ITeam team : a.getTeams()) {
-                        if (!(team instanceof BedWarsTeam)) continue;
-                        IBedHolo bedHolo = ((BedWarsTeam) team).getBedHologram(player);
-                        if (!player.getLocation().getWorld().equals(team.getBed().getWorld())) continue;
-                        if (player.getLocation().distance(team.getBed()) < 4) {
-                            if (team.isMember(player)) {
-                                if (bedHolo == null) continue;
-                                if (bedHolo.getHologram().isShowing()) bedHolo.getHologram().hide();
-                            }
-                        } else {
-                            if (team.isMember(player)) {
-                                if (bedHolo == null) continue;
-                                if (!bedHolo.getHologram().isShowing()) bedHolo.getHologram().show();
-                            }
-                        }
-                    }
                     if (e.getFrom() != e.getTo()) {
                         Arena.afkCheck.remove(player.getUniqueId());
                         BedWars.getAPI().getAFKUtil().setPlayerAFK(player, false);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
@@ -586,21 +586,22 @@ public class DamageDeathMove implements Listener {
         }
 
         if (a.isSpectator(player)) {
+            String iso = Language.getPlayerLanguage(player).getIso();
             e.setRespawnLocation(a.getSpectatorLocation());
             for (IGenerator o : a.getOreGenerators()) {
                 GeneratorHolder holder = o.getHologramHolder();
                 o.updateHolograms(player);
-                if (holder != null) holder.update();
+                if (holder != null) holder.update(player);
             }
             for (ITeam t : a.getTeams()) {
                 for (IGenerator o : t.getGenerators()) {
                     GeneratorHolder holder = o.getHologramHolder();
                     o.updateHolograms(player);
-                    if (holder != null) holder.update();
+                    if (holder != null) holder.update(player);
                 }
             }
-            for (ShopHolo sh : ShopHolo.getShopHolograms(player)) {
-                sh.update();
+            for (ShopHolo sh : a.getShopHolograms(iso)) {
+                sh.update(player);
             }
 
             a.sendSpectatorCommandItems(player);
@@ -649,43 +650,6 @@ public class DamageDeathMove implements Listener {
             IArena a = Arena.getArenaByPlayer(player);
             if (e.getFrom().getChunk() != e.getTo().getChunk()) {
                 /* update armor-stands hidden by nms */
-                for (IGenerator o : a.getOreGenerators()) {
-                    if (o.getType() == GeneratorType.DIAMOND || o.getType() == GeneratorType.EMERALD) {
-                        if (!a.getWorld().getPlayers().contains(player))
-                            return; // prevent location check between different worlds
-                        IGenHolo h = o.getPlayerHolograms().get(player);
-                        if (h != null) {
-                            if (o.getLocation().distance(e.getTo()) > BedWars.hologramUpdateDistance) h.update();
-                        }
-
-                        GeneratorHolder holder = o.getHologramHolder();
-                        if (holder != null) {
-                            if (holder.getArmorStand().getLocation().distance(e.getTo()) > BedWars.hologramUpdateDistance)
-                                holder.update();
-                        }
-                    }
-                }
-
-                for (ITeam t : a.getTeams()) {
-                    for (IGenerator o : t.getGenerators()) {
-                        IGenHolo h = o.getPlayerHolograms().get(player);
-                        if (h != null) {
-                            if (o.getLocation().distance(e.getTo()) > BedWars.hologramUpdateDistance) h.update();
-                        }
-
-                        GeneratorHolder holder = o.getHologramHolder();
-                        if (holder != null) {
-                            if (holder.getArmorStand().getLocation().distance(e.getTo()) > BedWars.hologramUpdateDistance)
-                                holder.update();
-                        }
-                    }
-                }
-
-                for (ShopHolo sh : ShopHolo.getShopHolograms(player)) {
-                    if (sh.getHologram().getLocation().distance(e.getTo()) > BedWars.hologramUpdateDistance)
-                        sh.update();
-                }
-
                 // hide armor for those with invisibility potions
                 if (!a.getShowTime().isEmpty()) {
                     // generic hide packets

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/DefaultGenAnimation.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/DefaultGenAnimation.java
@@ -74,7 +74,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.getId(), 0, (long) ((getArmorStandMotY() - lastMotY)*128), 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/HoloLine.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/HoloLine.java
@@ -26,6 +26,7 @@ import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -48,9 +49,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(metadataPacket);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(teleportPacket);
+        }
     }
 
     @Override
@@ -94,25 +98,67 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
 
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(metadataPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.setCustomName(text);
+        Location loc = hologram.getLocation();
+        int position = hologram.getLines().indexOf(this);
+        entity.setLocation(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        if (destroyed) return;
+
+        PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
+        pc.sendPacket(metadataPacket);
     }
 
     @Override
     public void reveal() {
         destroyed = false;
-
         PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+        PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
     }
 
     @Override

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/Hologram.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/Hologram.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -830,8 +830,11 @@ public class v1_12_R1 extends VersionSupport {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         World world = armorStand.getWorld();
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
         }
     }
 

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -31,6 +31,7 @@ import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.exceptions.InvalidEffectException;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -254,11 +255,7 @@ public class v1_12_R1 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -771,31 +768,6 @@ public class v1_12_R1 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            PlayerConnection connection = ((CraftPlayer) p).getHandle().playerConnection;
-            connection.sendPacket(spawn);
-            connection.sendPacket(metadata);
-            connection.sendPacket(equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -812,6 +784,22 @@ public class v1_12_R1 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -822,20 +810,45 @@ public class v1_12_R1 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(gh.getHelmet()));
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(spawn);
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet));
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle());
         nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -43,6 +43,7 @@ import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.World;
 import org.bukkit.block.Bed;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.Command;
@@ -825,11 +826,11 @@ public class v1_12_R1 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet));
-        for (Player p : players) {
+        World world = armorStand.getWorld();
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
         }
     }

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/DefaultGenAnimation.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/DefaultGenAnimation.java
@@ -70,7 +70,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.getId(), MathHelper.floor(loc.getX() * 32), MathHelper.floor(loc.getY() * 32), MathHelper.floor(loc.getZ() * 32), (byte) 0, (byte) 0, false);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.getId(), (byte) 0, (byte) getArmorStandMotY(), (byte) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
 

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/HoloLine.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/HoloLine.java
@@ -26,6 +26,7 @@ import net.minecraft.server.v1_8_R3.*;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -48,9 +49,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(metadataPacket);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(teleportPacket);
+        }
     }
 
     @Override
@@ -94,24 +98,67 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
 
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(metadataPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.setCustomName(text);
+        Location loc = hologram.getLocation();
+        int position = hologram.getLines().indexOf(this);
+        entity.setLocation(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        if (destroyed) return;
+
+        PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
+        pc.sendPacket(metadataPacket);
     }
 
     @Override
     public void reveal() {
         destroyed = false;
         PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+        PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
     }
 
     @Override

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
@@ -87,7 +87,7 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update(player);
+        update();
     }
 
     @Override

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update(player);
     }
 
     @Override
@@ -93,6 +128,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -897,8 +897,11 @@ public class v1_8_R3 extends VersionSupport {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         World world = armorStand.getWorld();
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
         }
     }
 

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -31,6 +31,7 @@ import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.exceptions.InvalidEffectException;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -314,11 +315,7 @@ public class v1_8_R3 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -838,30 +835,6 @@ public class v1_8_R3 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder gh) {
-        ArmorStand armorStand = gh.getArmorStand();
-        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(gh.getHelmet()));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(spawn);
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(metadata);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(helmet));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -878,6 +851,22 @@ public class v1_8_R3 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -888,20 +877,45 @@ public class v1_8_R3 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(gh.getHelmet()));
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(spawn);
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(helmet));
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle());
         nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -41,6 +41,7 @@ import net.minecraft.server.v1_8_R3.*;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
@@ -892,11 +893,11 @@ public class v1_8_R3 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(helmet));
-        for (Player p : players) {
+        World world = armorStand.getWorld();
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), 4, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
         }
     }

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/DefaultGenAnimation.java
@@ -73,7 +73,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.getId(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/HoloLine.java
@@ -27,6 +27,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -50,10 +51,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection;
-        connection.sendPacket(packet);
-        connection.sendPacket(metadataPacket);
-        connection.sendPacket(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(teleportPacket);
+        }
     }
 
     @Override
@@ -97,9 +100,27 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection;
-        connection.sendPacket(metadataPacket);
-        connection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.setCustomName(CraftChatMessage.fromStringOrNull(text));
+        Location loc = hologram.getLocation();
+        int position = hologram.getLines().indexOf(this);
+        entity.setLocation(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        if (destroyed) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
+        PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(metadataPacket);
+        pc.sendPacket(packet);
     }
 
     @Override
@@ -107,16 +128,41 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        pc.sendPacket(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().playerConnection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().playerConnection;
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
+        pc.sendPacket(packet);
     }
 
     @Override

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/Hologram.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/Hologram.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -43,6 +43,7 @@ import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -828,13 +829,13 @@ public class v1_16_R3 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
         }
     }

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -33,6 +33,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -248,11 +249,7 @@ public class v1_16_R3 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -772,33 +769,6 @@ public class v1_16_R3 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            PlayerConnection connection = ((CraftPlayer) p).getHandle().playerConnection;
-            connection.sendPacket(spawn);
-            connection.sendPacket(metadata);
-            connection.sendPacket(equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -815,6 +785,22 @@ public class v1_16_R3 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -825,20 +811,49 @@ public class v1_16_R3 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(spawn);
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
-        nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), 0, 0);
+        nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -835,8 +835,11 @@ public class v1_16_R3 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.HEAD, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().playerConnection.sendPacket(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().playerConnection;
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
         }
     }
 

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/DefaultGenAnimation.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/DefaultGenAnimation.java
@@ -79,7 +79,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.getId(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/HoloLine.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/HoloLine.java
@@ -29,6 +29,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -51,10 +52,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.sendPacket(packet);
-        connection.sendPacket(metadataPacket);
-        connection.sendPacket(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.sendPacket(packet);
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(teleportPacket);
+        }
     }
 
     @Override
@@ -98,9 +101,27 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
         PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.sendPacket(metadataPacket);
-        connection.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.sendPacket(metadataPacket);
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.setCustomName(CraftChatMessage.fromStringOrNull(text));
+        Location loc = hologram.getLocation();
+        int position = hologram.getLines().indexOf(this);
+        entity.setLocation(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ(), loc.getYaw(), loc.getPitch());
+        if (destroyed) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.getId(), entity.getDataWatcher(), true);
+        PacketPlayOutEntityTeleport packet = new PacketPlayOutEntityTeleport(entity);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.sendPacket(metadataPacket);
+        pc.sendPacket(packet);
     }
 
     @Override
@@ -108,16 +129,41 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.sendPacket(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.sendPacket(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.sendPacket(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.getId());
+        pc.sendPacket(packet);
     }
 
     @Override

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/Hologram.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/Hologram.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -30,6 +30,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -276,11 +277,7 @@ public class v1_17_R1 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -805,33 +802,6 @@ public class v1_17_R1 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            PlayerConnection connection = ((CraftPlayer) p).getHandle().b;
-            connection.sendPacket(spawn);
-            connection.sendPacket(equipment);
-            connection.sendPacket(metadata);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.sendPacket(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -848,6 +818,22 @@ public class v1_17_R1 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -858,20 +844,49 @@ public class v1_17_R1 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.sendPacket(spawn);
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().b.sendPacket(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.sendPacket(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), 0, 0, 0);
-        nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), 0, 0);
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.setLocation(loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(), loc.getPitch());
         PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.sendPacket(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -67,10 +67,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBase;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -861,13 +858,13 @@ public class v1_17_R1 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().b.sendPacket(equipment);
         }
     }

--- a/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -864,8 +864,11 @@ public class v1_17_R1 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().getDataWatcher(), true);
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.sendPacket(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.sendPacket(equipment);
+            pc.sendPacket(metadata);
         }
     }
 

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/DefaultGenAnimation.java
@@ -80,7 +80,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ae(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/HoloLine.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/HoloLine.java
@@ -27,9 +27,9 @@ import net.minecraft.server.network.PlayerConnection;
 import net.minecraft.world.entity.decoration.EntityArmorStand;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_18_R2.entity.CraftArmorStand;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -41,10 +41,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.a(CraftChatMessage.fromStringOrNull(text));
-        entity.n(true);
-        entity.j(true);
-        entity.Q = true;
+        entity.a(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.n(true); // setCustomNameVisible
+        entity.j(true); // setInvisible
+        entity.Q = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -52,10 +52,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ae(), entity.ai(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.a(packet);
-        connection.a(metadataPacket);
-        connection.a(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+            pc.a(metadataPacket);
+            pc.a(teleportPacket);
+        }
     }
 
     @Override
@@ -98,9 +100,26 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ae(), entity.ai(), true);
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.a(metadataPacket);
-        connection.a(teleportPacket);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(metadataPacket);
+            pc.a(teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.a(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.o(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (destroyed) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ae(), entity.ai(), true);
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.a(metadataPacket);
+        pc.a(teleportPacket);
     }
 
     @Override
@@ -108,16 +127,41 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.a(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.a(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ae());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.a(packet);
+        for (Player player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ae());
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.a(packet);
     }
 
     @Override

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/Hologram.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/Hologram.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -835,8 +835,11 @@ public class v1_18_R2 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ai(), true);
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.a(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.a(equipment);
+            pc.a(metadata);
         }
     }
 

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -58,10 +58,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBase;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -832,13 +829,13 @@ public class v1_18_R2 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().b.a(equipment);
         }
     }

--- a/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -32,6 +32,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -258,11 +259,7 @@ public class v1_18_R2 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -775,33 +772,6 @@ public class v1_18_R2 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ai(), true);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            PlayerConnection connection = ((CraftPlayer) p).getHandle().b;
-            connection.a(spawn);
-            connection.a(equipment);
-            connection.a(metadata);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.a(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -818,6 +788,22 @@ public class v1_18_R2 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -828,20 +814,50 @@ public class v1_18_R2 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand handle = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(handle);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), handle.ai(), true);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.a(spawn);
+            pc.a(equipment);
+            pc.a(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().b.a(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.a(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), 0, 0, 0);
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.o(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntityLiving spawn = new PacketPlayOutSpawnEntityLiving(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.a(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/DefaultGenAnimation.java
@@ -79,7 +79,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.af(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/HoloLine.java
@@ -32,6 +32,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -43,10 +44,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.n(true);
-        entity.j(true);
-        entity.ae = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.n(true); // setCustomNameVisible
+        entity.j(true); // setInvisible
+        entity.ae = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.p(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -54,10 +55,12 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.af(), entity.aj().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.a(packet);
-        connection.a(metadataPacket);
-        connection.a(teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+            pc.a(metadataPacket);
+            pc.a(teleportPacket);
+        }
     }
 
     @Override
@@ -100,9 +103,26 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.af(), entity.aj().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        PlayerConnection connection = ((CraftPlayer) hologram.getPlayer()).getHandle().b;
-        connection.a(metadataPacket);
-        connection.a(teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(metadataPacket);
+            pc.a(teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.af(), entity.aj().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.a(metadataPacket);
+        pc.a(teleportPacket);
     }
 
     @Override
@@ -110,16 +130,41 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.a(packet);
+        for (var player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        pc.a(packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.af());
-        ((CraftPlayer) hologram.getPlayer()).getHandle().b.a(packet);
+        for (var player : hologram.getPlayers()) {
+            PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+            pc.a(packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PlayerConnection pc = ((CraftPlayer) player).getHandle().b;
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.af());
+        pc.a(packet);
     }
 
     @Override

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/Hologram.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/Hologram.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
@@ -944,13 +944,13 @@ public class v1_19_R3 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             ((CraftPlayer) p).getHandle().b.a(equipment);
         }
     }

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
@@ -30,6 +30,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -278,11 +279,7 @@ public class v1_19_R3 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -887,33 +884,6 @@ public class v1_19_R3 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().aj().c());
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            PlayerConnection connection = ((CraftPlayer) p).getHandle().b;
-            connection.a(spawn);
-            connection.a(equipment);
-            connection.a(metadata);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.a(equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -930,6 +900,22 @@ public class v1_19_R3 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @Nonnull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -940,20 +926,50 @@ public class v1_19_R3 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand handle = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(handle);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), handle.aj().c());
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.a(spawn);
+            pc.a(equipment);
+            pc.a(metadata);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            ((CraftPlayer) p).getHandle().b.a(equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.a(destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), 0, 0, 0);
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             ((CraftPlayer) p).getHandle().b.a(spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
+++ b/versionsupport_v1_19_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_19_R3/v1_19_R3.java
@@ -950,8 +950,11 @@ public class v1_19_R3 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().aj().c());
         for (Player p : world.getPlayers()) {
-            ((CraftPlayer) p).getHandle().b.a(equipment);
+            PlayerConnection pc = ((CraftPlayer) p).getHandle().b;
+            pc.a(equipment);
+            pc.a(metadata);
         }
     }
 

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/DefaultGenAnimation.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/DefaultGenAnimation.java
@@ -77,7 +77,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.al(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_20_6.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/HoloLine.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/HoloLine.java
@@ -31,6 +31,7 @@ import net.minecraft.world.entity.decoration.EntityArmorStand;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -42,7 +43,7 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
+        entity.b(CraftChatMessage.fromStringOrNull(text)); //setCustomName
         entity.o(true); //setCustomNameVisible
         entity.k(true); //setInvisible
         entity.ag = true; //noPhysics
@@ -53,7 +54,9 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c()); //getId, getEntityData
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_20_6.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_20_6.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -96,7 +99,22 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c()); //getId, getEntityData
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_20_6.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_20_6.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text)); //setCustomName
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ()); //setPosRaw
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c()); //getId, getEntityData
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_20_6.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -104,16 +122,37 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
-        v1_20_6.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_20_6.sendPacket(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
+        v1_20_6.sendPacket(player, packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.al()); //getId
-        v1_20_6.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_20_6.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.al()); //getId
+        v1_20_6.sendPacket(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/Hologram.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/Hologram.java
@@ -30,30 +30,65 @@ import java.util.List;
 import java.util.logging.Logger;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -90,6 +125,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/Hologram.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/hologram/Hologram.java
@@ -88,7 +88,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
@@ -816,13 +816,13 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
@@ -822,8 +822,9 @@ public final class v1_20_6 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ap().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
+++ b/versionsupport_v1_20_6/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_6/v1_20_6.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -211,11 +212,7 @@ public final class v1_20_6 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -762,30 +759,6 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ap().c());
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -802,6 +775,22 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -812,23 +801,47 @@ public final class v1_20_6 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand handle = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(handle);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), handle.ap().c());
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/DefaultGenAnimation.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/DefaultGenAnimation.java
@@ -81,7 +81,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.al(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_20_R4.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/HoloLine.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/HoloLine.java
@@ -31,6 +31,7 @@ import net.minecraft.world.entity.decoration.EntityArmorStand;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -42,10 +43,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.o(true);
-        entity.k(true);
-        entity.ag = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.o(true); // setCustomNameVisible
+        entity.k(true); // setInvisible
+        entity.ag = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.p(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -53,7 +54,9 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_20_R4.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_20_R4.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -96,7 +99,22 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_20_R4.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_20_R4.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.al(), entity.ap().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_20_R4.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -104,16 +122,37 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
-        v1_20_R4.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_20_R4.sendPacket(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity(entity);
+        v1_20_R4.sendPacket(player, packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.al());
-        v1_20_R4.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_20_R4.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.al());
+        v1_20_R4.sendPacket(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/Hologram.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/Hologram.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -211,11 +212,7 @@ public final class v1_20_R4 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -762,30 +759,6 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(((CraftArmorStand) armorStand).getHandle());
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ap().c());
-        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -802,6 +775,22 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -812,23 +801,47 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand handle = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(handle);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), handle.ap().c());
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.p(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = new PacketPlayOutSpawnEntity(nmsEntity);
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -822,8 +822,9 @@ public final class v1_20_R4 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ap().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_r4/src/main/java/com/tomkeuper/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -816,13 +816,13 @@ public final class v1_20_R4 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/DefaultGenAnimation.java
@@ -77,7 +77,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand);
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.an(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_21_R1.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/HoloLine.java
@@ -31,6 +31,7 @@ import net.minecraft.world.entity.decoration.EntityArmorStand;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 public class HoloLine implements IHoloLine {
     private String text;
@@ -42,10 +43,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.p(true);
-        entity.k(true);
-        entity.ag = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.p(true); // setCustomNameVisible
+        entity.k(true); // setInvisible
+        entity.ag = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -53,7 +54,9 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R1.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R1.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -96,7 +99,22 @@ public class HoloLine implements IHoloLine {
         PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
 
-        v1_21_R1.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R1.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.an(), entity.ar().c());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity);
+
+        v1_21_R1.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -104,16 +122,37 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = v1_21_R1.newPacketPlayOutSpawnEntity(entity);
-        v1_21_R1.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R1.sendPacket(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R1.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R1.sendPacket(player, packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
-        v1_21_R1.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R1.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.an());
+        v1_21_R1.sendPacket(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/Hologram.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/Hologram.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -825,13 +825,13 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -831,8 +831,9 @@ public final class v1_21_R1 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
+++ b/versionsupport_v1_21_r1/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R1/v1_21_R1.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -217,11 +218,7 @@ public final class v1_21_R1 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -772,31 +769,6 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
-        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
-        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -813,6 +785,22 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -823,24 +811,48 @@ public final class v1_21_R1 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().ar().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        if (loc.getWorld() == null) throw new RuntimeException("World of a location should not be null.");
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/DefaultGenAnimation.java
@@ -87,7 +87,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
 
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_21_R2.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/HoloLine.java
@@ -34,6 +34,7 @@ import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R2.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -48,10 +49,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.p(true);
-        entity.k(true);
-        entity.ag = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.p(true); // setCustomNameVisible
+        entity.k(true); // setInvisible
+        entity.ag = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -63,7 +64,9 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R2.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -110,7 +113,26 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
 
-        v1_21_R2.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R2.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R2.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -118,16 +140,37 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
-        v1_21_R2.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R2.sendPacket(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R2.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R2.sendPacket(player, packet);
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update(player);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
-        v1_21_R2.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R2.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
+        v1_21_R2.sendPacket(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -814,8 +814,9 @@ public final class v1_21_R2 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -808,13 +808,13 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }

--- a/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
+++ b/versionsupport_v1_21_r2/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R2/v1_21_R2.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -213,11 +214,7 @@ public final class v1_21_R2 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -755,31 +752,6 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
-        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
-        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -796,6 +768,22 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -806,24 +794,48 @@ public final class v1_21_R2 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        if (loc.getWorld() == null) throw new RuntimeException("World of a location should not be null.");
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/DefaultGenAnimation.java
@@ -87,7 +87,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
 
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_21_R3.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/HoloLine.java
@@ -34,6 +34,7 @@ import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R3.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -48,10 +49,10 @@ public class HoloLine implements IHoloLine {
         this.text = text;
         this.hologram = hologram;
         entity = new EntityArmorStand(((CraftWorld) hologram.getLocation().getWorld()).getHandle(), 0, 0, 0);
-        entity.b(CraftChatMessage.fromStringOrNull(text));
-        entity.p(true);
-        entity.k(true);
-        entity.ag = true;
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.p(true); // setCustomNameVisible
+        entity.k(true); // setInvisible
+        entity.ag = true; // noPhysics
         Location loc = hologram.getLocation();
         entity.o(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
@@ -63,7 +64,9 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R3.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -110,7 +113,26 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
 
-        v1_21_R3.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R3.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ());
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c());
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.du(), delta, 0, entity.dN());
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(),positionMoveRotation, set, false);
+
+        v1_21_R3.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -118,16 +140,34 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
-        v1_21_R3.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R3.sendPackets(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R3.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R3.sendPackets(player, packet);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
-        v1_21_R3.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R3.sendPackets(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
+        v1_21_R3.sendPackets(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -213,11 +214,7 @@ public final class v1_21_R3 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -753,31 +750,6 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
-        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
-        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -794,6 +766,22 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -804,24 +792,48 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        if (loc.getWorld() == null) throw new RuntimeException("World of a location should not be null.");
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -806,13 +806,13 @@ public final class v1_21_R3 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }

--- a/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
+++ b/versionsupport_v1_21_r3/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R3/v1_21_R3.java
@@ -812,8 +812,9 @@ public final class v1_21_R3 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/DefaultGenAnimation.java
@@ -87,7 +87,7 @@ public class DefaultGenAnimation implements IGeneratorAnimation {
 
         PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.ar(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
 
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+        for (Player p : loc.getWorld().getPlayers()) {
             v1_21_R5.sendPackets(p, teleportPacket, moveLookPacket);
         }
         tickCount++;

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/HoloLine.java
@@ -34,6 +34,7 @@ import net.minecraft.world.phys.Vec3D;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_21_R5.CraftWorld;
 import org.bukkit.craftbukkit.v1_21_R5.util.CraftChatMessage;
+import org.bukkit.entity.Player;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -63,7 +64,9 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(), positionMoveRotation, set, false);
 
-        v1_21_R5.sendPackets(hologram.getPlayer(), packet, metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R5.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
     }
 
     @Override
@@ -110,7 +113,26 @@ public class HoloLine implements IHoloLine {
         final Set<Relative> set = new HashSet<>();
         PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(), positionMoveRotation, set, false); // getId()
 
-        v1_21_R5.sendPackets(hologram.getPlayer(), metadataPacket, teleportPacket);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R5.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        int position = hologram.getLines().indexOf(this);
+        entity.p(hologram.getLocation().getX(), hologram.getLocation().getY() + position * hologram.getGap(), hologram.getLocation().getZ()); //
+        if (isDestroyed()) return;
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entity.ar(), entity.au().c()); // getId(), getEntityData()
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dw(), delta, 0, entity.dR()); // trackingPosition(), , , getXRot()
+        final Set<Relative> set = new HashSet<>();
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entity.ar(), positionMoveRotation, set, false); // getId()
+
+        v1_21_R5.sendPackets(player, metadataPacket, teleportPacket);
     }
 
     @Override
@@ -118,16 +140,34 @@ public class HoloLine implements IHoloLine {
         destroyed = false;
 
         PacketPlayOutSpawnEntity packet = v1_21_R5.newPacketPlayOutSpawnEntity(entity);
-        v1_21_R5.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R5.sendPacket(player, packet);
+        }
 
         if (!hologram.getLines().contains(this)) hologram.addLine(this);
         hologram.update();
     }
 
     @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R5.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R5.sendPacket(player, packet);
+    }
+
+    @Override
     public void remove() {
         PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
-        v1_21_R5.sendPacket(hologram.getPlayer(), packet);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R5.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.ar());
+        v1_21_R5.sendPacket(player, packet);
     }
 
     @Override

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
@@ -87,7 +87,6 @@ public class Hologram implements IHologram {
         for (IHoloLine line : this.lines) {
             line.remove(player);
         }
-        update();
     }
 
     @Override

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/hologram/Hologram.java
@@ -29,30 +29,65 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hologram implements IHologram {
-    private final Player p;
+
+    private final List<Player> players;
     private List<IHoloLine> lines;
     private final Location loc;
     private double gap = 0.25;
     private boolean showing = true;
 
     public Hologram(Player p, List<IHoloLine> lines, Location loc) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.lines = lines;
         this.loc = loc;
     }
 
-    public Player getPlayer() {
-        return this.p;
-    }
-
     public Hologram(Player p, Location loc, List<String> lines) {
-        this.p = p;
+        this.players = new ArrayList<>();
+        this.players.add(p);
         this.loc = loc;
         this.lines = new ArrayList<>();
 
         for (String line : lines) {
             this.lines.add(new HoloLine(line, this));
         }
+    }
+
+    public Hologram(List<Player> players, List<String> lines, Location loc) {
+        this.players = players;
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(List<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = players;
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public List<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+        update();
     }
 
     @Override
@@ -89,6 +124,13 @@ public class Hologram implements IHologram {
     public void update() {
         for (IHoloLine line : this.lines) {
             line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        for (IHoloLine line : this.lines) {
+            line.update(player);
         }
     }
 

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -818,8 +818,9 @@ public final class v1_21_R5 extends VersionSupport {
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
         items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
         for (Player p : world.getPlayers()) {
-            sendPacket(p, equipment);
+            sendPackets(p, equipment, metadata);
         }
     }
 

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -34,6 +34,7 @@ import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
 import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
 import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
 import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
 import com.tomkeuper.bedwars.api.language.Messages;
 import com.tomkeuper.bedwars.api.server.VersionSupport;
 import com.tomkeuper.bedwars.support.version.common.VersionCommon;
@@ -218,11 +219,7 @@ public final class v1_21_R5 extends VersionSupport {
             String[] nume = (getList(p, name1) == null || getList(p, name1).isEmpty() ? getList(p, name1.replace(name1.split("\\.")[2], "default")) : getList(p, name1)).toArray(new String[0]);
             IHologram h = createHologram(p, loc, nume);
 
-            new ShopHolo(h, loc, arena, team);
-        }
-
-        for (Player p : players) {
-            ShopHolo.getShopHolograms(p).forEach(ShopHolo::update);
+            new ShopHolo(h, arena, team).update();
         }
     }
 
@@ -759,31 +756,6 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
-    public void updatePacketArmorStand(GeneratorHolder generatorHolder) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
-        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
-        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
-        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet()));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPackets(p, spawn, metadata, equipment);
-        }
-    }
-
-    @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet) {
-        ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
-        Pair<EnumItemSlot, ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet));
-        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
-        for (Player p : armorStand.getWorld().getPlayers()) {
-            sendPacket(p, equipment);
-        }
-    }
-
-    @Override
     public IHologram createHologram(Player p, Location location, String... lines) {
         List<String> linesList = new ArrayList<>(Arrays.asList(lines));
         // holograms are reversed, correcting that here
@@ -800,6 +772,22 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
+    public IHologram createHologram(List<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(List<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
     public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
         return new HoloLine(text, hologram);
     }
@@ -810,24 +798,48 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
-    public void destroyPacketArmorStand(GeneratorHolder generatorHolder) {
+    public void updatePacketArmorStand(GeneratorHolder gh, List<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().au().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        generatorHolder.setHelmet(helmet, false);
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        for (Player p : players) {
+            sendPacket(p, equipment);
+        }
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, List<Player> players) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
         PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
-        for (Player p : armorStand.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, destroy);
         }
     }
 
     @Override
-    public ArmorStand createPacketArmorStand(Location loc) {
-        if (loc.getWorld() == null) {
-            throw new RuntimeException("World of a location should not be null.");
-        }
+    public ArmorStand createPacketArmorStand(Location loc, List<Player> players) {
+        if (loc.getWorld() == null) throw new RuntimeException("World of a location should not be null.");
         EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
         nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
         PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
 
-        for (Player p : loc.getWorld().getPlayers()) {
+        for (Player p : players) {
             sendPacket(p, spawn);
         }
         return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);

--- a/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
+++ b/versionsupport_v1_21_r5/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R5/v1_21_R5.java
@@ -812,13 +812,13 @@ public final class v1_21_R5 extends VersionSupport {
     }
 
     @Override
-    public void setGeneratorHolderHelmet(GeneratorHolder generatorHolder, org.bukkit.inventory.ItemStack helmet, List<Player> players) {
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
         ArmorStand armorStand = generatorHolder.getArmorStand();
-        generatorHolder.setHelmet(helmet, false);
+        World world = armorStand.getWorld();
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(helmet)));
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
         PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
-        for (Player p : players) {
+        for (Player p : world.getPlayers()) {
             sendPacket(p, equipment);
         }
     }


### PR DESCRIPTION
- Allow IHologram holders to contain more than 1 player at once
- Add methods to IHoloLine to hide/show lines per player
- Improve ShopHolo to work based on arena instead of per player
- Replace Hologram system with language system instead of per player, this reduces memory usage
- Replace hologram update system to be updated based on a value in config.yml instead of everytime a player moved, this reduces CPU usage as less holograms are stored and it's not called in big loads
- Remove unused imports
- Optimized BedHologram to match language iso system instead of previous per player system
- Optimize BedHologram system to use less memory and cpu by making it language based and updating it after x ticks instead of every player move
- Optimize GenAnimation to send packets to player in a world instead to the entire server