### PR TITLE
feat: added support for mc 1.21.11

### DIFF
--- a/bedwars-plugin/build.gradle
+++ b/bedwars-plugin/build.gradle
@@ -69,10 +69,10 @@ dependencies {
     compileOnly 'de.dytanic.cloudnet:cloudnet-wrapper-jvm:3.4.5-RELEASE'
     slim 'redis.clients:jedis:5.0.2'
     slim 'com.flowpowered:flow-nbt:2.0.2'
-    slim 'com.saicone.rtag:rtag:1.5.13'
-    slim 'com.saicone.rtag:rtag-block:1.5.13'
-    slim 'com.saicone.rtag:rtag-entity:1.5.13'
-    slim 'com.saicone.rtag:rtag-item:1.5.13'
+    slim 'com.saicone.rtag:rtag:1.5.16'
+    slim 'com.saicone.rtag:rtag-block:1.5.16'
+    slim 'com.saicone.rtag:rtag-entity:1.5.16'
+    slim 'com.saicone.rtag:rtag-item:1.5.16'
 }
 
 bukkit {
@@ -122,6 +122,7 @@ def versions = [
     ':versionsupport_v1_21_r2',
     ':versionsupport_v1_21_r3',
     ':versionsupport_v1_21_r5',
+    ':versionsupport_v1_21_r7',
     ':resetadapter_slime',
     ':resetadapter_slimepaper',
     ':resetadapter_advancedslimepaper',

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -246,6 +246,8 @@ public class BedWars extends JavaPlugin {
             case "1.21.8":
                 nmsVersion = "v1_21_R5";
                 break;
+            case "1.21.11":
+                nmsVersion = "v1_21_R7";
             default:
                 break;
         }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ def versions = [
     ':versionsupport_v1_21_r2',
     ':versionsupport_v1_21_r3',
     ':versionsupport_v1_21_r5',
+    ':versionsupport_v1_21_r7',
     ':resetadapter_slime',
     ':resetadapter_slimepaper',
     ':resetadapter_advancedslimepaper',

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,12 +34,10 @@ include ':versionsupport_v1_20_6'
 include ':versionsupport_v1_21_r1'
 include ':versionsupport_v1_21_r2'
 include ':versionsupport_v1_21_r3'
+include ':versionsupport_v1_21_r5'
+include ':versionsupport_v1_21_r7'
 include ':versionsupport_common'
 
 
 // Enable type-safe project accessors for Kotlin DSL usages that remain
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
-
-
-// Include missing module for v1_21_r5
-include ':versionsupport_v1_21_r5'

--- a/versionsupport_v1_21_r7/build.gradle
+++ b/versionsupport_v1_21_r7/build.gradle
@@ -1,0 +1,27 @@
+dependencies {
+    compileOnly project(':bedwars-api')
+    implementation project(':versionsupport_common')
+    compileOnly('org.spigotmc:spigot:1.21.11-R0.2-SNAPSHOT') {
+        exclude group: 'commons-lang', module: 'commons-lang'
+    }
+    compileOnly 'com.saicone.rtag:rtag:1.5.16'
+    // Other modules
+    compileOnly 'com.saicone.rtag:rtag-block:1.5.16'
+    compileOnly 'com.saicone.rtag:rtag-entity:1.5.16'
+    compileOnly 'com.saicone.rtag:rtag-item:1.5.16'
+}
+
+tasks.named('compileJava', JavaCompile) {
+    options.release = 21
+}
+
+repositories {
+    // Important Repos
+    mavenCentral()
+    mavenLocal()
+    maven { url = uri('https://repo.codemc.io/repository/nms/') } // Spigot
+    maven { url = uri('https://repo.papermc.io/repository/maven-public/') } // com.mojang (dep of Spigot)
+    maven { url = uri('https://jitpack.io') } // Jitpack (RTag)
+}
+
+description = 'versionsupport_v1_21_r7'

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/DefaultGenAnimation.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/DefaultGenAnimation.java
@@ -1,0 +1,119 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7;
+
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import net.minecraft.network.protocol.game.PacketPlayOutEntity;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.Relative;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftArmorStand;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultGenAnimation implements IGeneratorAnimation {
+
+    private final Entity armorStand;
+    private final Location loc;
+    private int tickCount = 0; // A counter to keep track of the ticks since the animation started.
+
+    // Constants for the sinusoidal motion
+    final double frequency = 0.035; // Controls the oscillation speed.
+    final double amplitude = 260; // Controls the range of YAW motion.
+    final double verticalAmplitude = 0.15; // Controls the range of vertical motion.
+
+    public DefaultGenAnimation(ArmorStand armorStand) {
+        this.armorStand = ((CraftArmorStand) armorStand).getHandle();
+        this.loc = armorStand.getLocation();
+        setArmorStandYAW(0);
+        setArmorStandMotY(0);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "bw2023:default";
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("BedWars2023");
+    }
+
+    @Override
+    public void run() {
+        // Calculate sinusoidal values for YAW and MotY
+        float sinusoidalYaw = (float) (Math.sin(frequency * tickCount) * amplitude);
+        float sinusoidalMotY = (float) (Math.sin((frequency * tickCount) + Math.PI/2) * verticalAmplitude);
+
+        // Update the armor stand's YAW and MotY based on the sinusoidal functions
+        final double lastMotY = getArmorStandMotY();
+        setArmorStandYAW(sinusoidalYaw);
+        addArmorStandMotY(sinusoidalMotY);
+
+        armorStand.l(loc.getX(), loc.getY(), loc.getZ()); // SETTING NEW LOCATION
+        armorStand.bc = false; // SETTING ON GROUND TO FALSE
+
+        final var delta = new Vec3D(0,0,0);
+        final var positionMoveRotation = new PositionMoveRotation(armorStand.dJ(), delta, 0, 0);
+        final Set<Relative> set = new HashSet<>();
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(armorStand.aA(), positionMoveRotation, set, false);
+
+        PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook moveLookPacket = new PacketPlayOutEntity.PacketPlayOutRelEntityMoveLook(armorStand.aA(), (short) 0, (short) ((getArmorStandMotY() - lastMotY)*128), (short) 0, (byte) getArmorStandYAW(), (byte) 0, false);
+
+        for (Player p : loc.getWorld().getPlayers()) {
+            v1_21_R7.sendPackets(p, teleportPacket, moveLookPacket);
+        }
+        tickCount++;
+    }
+
+    private void setArmorStandYAW(float yaw) {
+        armorStand.v(yaw);
+    }
+
+    private void addArmorStandYAW(float yaw) {
+        armorStand.v(getArmorStandYAW() + yaw);
+    }
+
+    private float getArmorStandYAW() {
+        return armorStand.ec();
+    }
+
+    private void setArmorStandMotY(double y) {
+        armorStand.k(new Vec3D(0, y, 0));
+    }
+
+    private void addArmorStandMotY(double y) {
+        armorStand.k(new Vec3D(0, getArmorStandMotY() + y, 0));
+    }
+
+    private double getArmorStandMotY() {
+        return armorStand.dN().h;
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableAttributes.java
@@ -1,0 +1,25 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
+
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableFactory.java
@@ -1,0 +1,47 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DespawnableFactory {
+
+    private final VersionSupport versionSupport;
+    private final List<DespawnableProvider<? extends LivingEntity>> providers = new ArrayList<>();
+
+    public DespawnableFactory(VersionSupport versionSupport) {
+        this.versionSupport = versionSupport;
+        providers.add(new TeamIronGolem());
+        providers.add(new TeamSilverfish());
+    }
+
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, int pathFindingTicks){
+        return providers.stream().filter(provider -> provider.getType() == attr.type())
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport, pathFindingTicks);
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableProvider.java
@@ -1,0 +1,92 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.EntityInsentient;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.ai.attributes.GenericAttributes;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalSelector;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalNearestAttackableTarget;
+import net.minecraft.world.entity.player.EntityHuman;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public abstract class DespawnableProvider<T> {
+
+    abstract DespawnableType getType();
+
+    abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
+
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks);
+
+    protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
+        var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
+        return null == despawnable || despawnable.getTeam() != team;
+    }
+
+    protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.ct;
+    }
+
+    protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.cs;
+    }
+
+    protected void clearSelectors(@NotNull EntityCreature entityLiving) {
+        entityLiving.ct.b().clear();
+        entityLiving.cs.b().clear();
+    }
+
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api, int pathFindingTicks) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, pathFindingTicks, true, false,
+                (entityLiving, sourceEntity) -> { // Two parameters now
+                    if (entityLiving instanceof EntityHuman) {
+                        return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
+                                !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
+                                !team.getArena().isReSpawning(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId())
+                                && !team.getArena().isSpectator(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId());
+                    }
+                    return notSameTeam(entityLiving, team, api);
+                });
+    }
+
+    protected void applyDefaultSettings(org.bukkit.entity.@NotNull LivingEntity bukkitEntity, DespawnableAttributes attr,
+                                        ITeam team) {
+        bukkitEntity.setRemoveWhenFarAway(false);
+        bukkitEntity.setPersistent(true);
+        bukkitEntity.setCustomNameVisible(true);
+        bukkitEntity.setCustomName(getDisplayName(attr, team));
+
+        var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
+
+        Objects.requireNonNull(entity.fw().a(GenericAttributes.u)).a(attr.health());
+        Objects.requireNonNull(entity.fw().a(GenericAttributes.x)).a(attr.speed());
+        Objects.requireNonNull(entity.fw().a(GenericAttributes.d)).a(attr.damage());
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableType.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/DespawnableType.java
@@ -1,0 +1,26 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+public enum DespawnableType {
+    IRON_GOLEM,
+    SILVERFISH
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/TeamIronGolem.java
@@ -1,0 +1,78 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.animal.golem.EntityIronGolem;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamIronGolem extends DespawnableProvider<IronGolem> {
+
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.IRON_GOLEM;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
+
+        var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntityIronGolem) ((CraftEntity) bukkitEntity).getHandle();
+
+        clearSelectors(entity);
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.5D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/despawnable/TeamSilverfish.java
@@ -1,0 +1,76 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable;
+
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.monster.EntitySilverfish;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamSilverfish extends DespawnableProvider<Silverfish> {
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.SILVERFISH;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME).replace("%bw_despawn_time%", String.valueOf(attr.despawnSeconds())
+                .replace("%bw_health%", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("%bw_team_color%", team.getColor().chat().toString())
+        );
+    }
+
+    @Override
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api, int pathFindingTicks) {
+        var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntitySilverfish) ((CraftEntity) bukkitEntity).getHandle();
+        clearSelectors(entity);
+
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.9D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api, pathFindingTicks));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/HoloLine.java
@@ -52,7 +52,6 @@ public class HoloLine implements IHoloLine {
         entity.p(true); // setCustomNameVisible
         entity.l(true); // setInvisible
         entity.ag = true; // noPhysics (no gravity)
-        //entity.v(true); // setMarker - removes hitbox
         entity.a_(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
 
         PacketPlayOutSpawnEntity packet = v1_21_R7.newPacketPlayOutSpawnEntity(entity);

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/HoloLine.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/HoloLine.java
@@ -1,0 +1,201 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.v1_21_R7;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityTeleport;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R7.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+public class HoloLine implements IHoloLine {
+    private String text;
+    private IHologram hologram;
+    public final EntityArmorStand entity;
+    private boolean destroyed = false;
+
+    public HoloLine(String text, IHologram hologram) {
+        this.text = text;
+        this.hologram = hologram;
+        Location loc = hologram.getLocation();
+        entity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), 0, 0, 0);
+        entity.b(CraftChatMessage.fromStringOrNull(text)); // setCustomName
+        entity.p(true); // setCustomNameVisible
+        entity.l(true); // setInvisible
+        entity.ag = true; // noPhysics (no gravity)
+        //entity.v(true); // setMarker - removes hitbox
+        entity.a_(loc.getX(), loc.getY() + hologram.size() * hologram.getGap(), loc.getZ());
+
+        PacketPlayOutSpawnEntity packet = v1_21_R7.newPacketPlayOutSpawnEntity(entity);
+
+        int entityId = entity.aA();
+        var metadata = entity.aD().c();
+
+        if (null == metadata) metadata = new ArrayList<>();
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entityId, metadata);
+
+        final Vec3D delta = new Vec3D(0, 0, 0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dJ(), delta, 0, entity.ee());
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entityId, positionMoveRotation, new HashSet<>(), false);
+
+        for (var player : hologram.getPlayers()) {
+            v1_21_R7.sendPackets(player, packet, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void setText(String text) {
+        this.text = text;
+        update();
+    }
+
+    @Override
+    public void setText(String text, boolean update) {
+        this.text = text;
+
+        if (update) {
+            update();
+        }
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void setHologram(IHologram hologram) {
+        this.hologram = hologram;
+    }
+
+    @Override
+    public IHologram getHologram() {
+        return hologram;
+    }
+
+    @Override
+    public void update() {
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        Location loc = hologram.getLocation();
+        entity.a_(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ());
+        if (isDestroyed()) return;
+
+        int entityId = entity.aA();
+        var metadata = entity.aD().c();
+
+        if (null == metadata) metadata = new ArrayList<>();
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entityId, metadata);
+
+        final Vec3D delta = new Vec3D(0, 0, 0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dJ(), delta, 0, entity.ee());
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entityId, positionMoveRotation, new HashSet<>(), false);
+
+        for (var player : hologram.getPlayers()) {
+            v1_21_R7.sendPackets(player, metadataPacket, teleportPacket);
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        if (!hologram.getPlayers().contains(player)) return;
+        entity.b(CraftChatMessage.fromStringOrNull(text));
+        int position = hologram.getLines().indexOf(this);
+        Location loc = hologram.getLocation();
+        entity.a_(loc.getX(), loc.getY() + position * hologram.getGap(), loc.getZ());
+        if (isDestroyed()) return;
+
+        int entityId = entity.aA();
+        var metadataUpdate = entity.aD().c();
+
+        if (null == metadataUpdate) metadataUpdate = new ArrayList<>();
+
+        PacketPlayOutEntityMetadata metadataPacket = new PacketPlayOutEntityMetadata(entityId, metadataUpdate);
+
+        final Vec3D delta = new Vec3D(0, 0, 0);
+        final var positionMoveRotation = new PositionMoveRotation(entity.dJ(), delta, 0, entity.ee());
+
+        PacketPlayOutEntityTeleport teleportPacket = new PacketPlayOutEntityTeleport(entityId, positionMoveRotation, new HashSet<>(), false);
+
+        v1_21_R7.sendPackets(player, metadataPacket, teleportPacket);
+    }
+
+    @Override
+    public void reveal() {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R7.newPacketPlayOutSpawnEntity(entity);
+        for (var player : hologram.getPlayers()) {
+            v1_21_R7.sendPacket(player, packet);
+        }
+
+        if (!hologram.getLines().contains(this)) hologram.addLine(this);
+        hologram.update();
+    }
+
+    @Override
+    public void reveal(Player player) {
+        destroyed = false;
+
+        PacketPlayOutSpawnEntity packet = v1_21_R7.newPacketPlayOutSpawnEntity(entity);
+        v1_21_R7.sendPacket(player, packet);
+    }
+
+    @Override
+    public void remove() {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.aA());
+        for (var player : hologram.getPlayers()) {
+            v1_21_R7.sendPacket(player, packet);
+        }
+    }
+
+    @Override
+    public void remove(Player player) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(entity.aA());
+        v1_21_R7.sendPacket(player, packet);
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+        remove();
+        hologram.removeLine(this);
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return destroyed;
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/Hologram.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/hologram/Hologram.java
@@ -1,0 +1,341 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7.hologram;
+
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Hologram implements IHologram {
+
+    private final Set<Player> players;
+    private List<IHoloLine> lines;
+    private final Location loc;
+    private double gap = 0.25;
+    private boolean showing = true;
+
+    public Hologram(Player p, List<IHoloLine> lines, Location loc) {
+        this.players = new HashSet<>();
+        this.players.add(p);
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    public Hologram(Player p, Location loc, List<String> lines) {
+        this.players = new HashSet<>();
+        this.players.add(p);
+        this.loc = loc;
+        this.lines = new ArrayList<>();
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(Iterable<Player> players, List<String> lines, Location loc) {
+        this.players = new HashSet<>();
+        for (Player p : players) this.players.add(p);
+        this.lines = new ArrayList<>();
+        this.loc = loc;
+
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+    }
+
+    public Hologram(Iterable<Player> players, Location loc, List<IHoloLine> lines) {
+        this.players = new HashSet<>();
+        for (Player p : players) this.players.add(p);
+        this.lines = lines;
+        this.loc = loc;
+    }
+
+    @Override
+    public Set<Player> getPlayers() {
+        return this.players;
+    }
+
+    @Override
+    public void addPlayer(Player player) {
+        this.players.add(player);
+        update();
+    }
+
+    @Override
+    public void removePlayer(Player player) {
+        this.players.remove(player);
+        for (IHoloLine line : this.lines) {
+            line.remove(player);
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line) {
+        this.lines.add(line);
+    }
+
+    @Override
+    public void removeLine(IHoloLine line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public void removeLine(int index) {
+        this.lines.remove(index);
+    }
+
+    @Override
+    public void removeLineContaining(String text) {
+        for (IHoloLine line : this.lines) {
+            if (line.getText().contains(text)) {
+                line.remove();
+                break; // Only remove 1 line
+            }
+        }
+    }
+
+    @Override
+    public void clearLines() {
+        this.lines.clear();
+    }
+
+    @Override
+    public void update() {
+        for (IHoloLine line : this.lines) {
+            line.update();
+        }
+    }
+
+    @Override
+    public void update(Player player) {
+        if (!this.players.contains(player)) return;
+        for (IHoloLine line : this.lines) {
+            line.update(player);
+        }
+    }
+
+    @Override
+    public void show() {
+        this.showing = true;
+        for (IHoloLine line : this.lines) {
+            line.reveal();
+        }
+    }
+
+    @Override
+    public void hide() {
+        this.showing = false;
+        for (IHoloLine line : this.lines) {
+            line.remove();
+        }
+    }
+
+    @Override
+    public boolean isShowing() {
+        return showing;
+    }
+
+    @Override
+    public int size() {
+        return this.lines.size();
+    }
+
+    @Override
+    public IHoloLine getLine(int index) {
+        return this.lines.get(index);
+    }
+
+    @Override
+    public List<IHoloLine> getLines() {
+        return this.lines;
+    }
+
+    @Override
+    public Location getLocation() {
+        return this.loc;
+    }
+
+    @Override
+    public void setLines(String[] lines, boolean update) {
+        this.lines.clear();
+        for (String line : lines) {
+            this.lines.add(new HoloLine(line, this));
+        }
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLines(List<IHoloLine> lines, boolean update) {
+        this.lines = lines;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line) {
+        this.lines.set(index, line);
+        this.lines.get(index).update();
+    }
+
+    @Override
+    public void setLine(int index, IHoloLine line, boolean update) {
+        this.lines.set(index, line);
+        if (update) {
+            this.lines.get(index).update();
+        }
+    }
+
+    @Override
+    public void setLine(int index, String line) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line);
+    }
+
+    @Override
+    public void setLine(int index, String line, boolean update) {
+        if (this.lines.isEmpty()) {
+            this.lines.add(new HoloLine(line, this));
+            return;
+        }
+
+        if (this.lines.get(index) == null) {
+            this.lines.add(index, new HoloLine(line, this));
+            return;
+        }
+        this.lines.get(index).setText(line, update);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line) {
+        this.lines.remove(index);
+        this.lines.add(index, line);
+    }
+
+    @Override
+    public void insertLine(int index, IHoloLine line, boolean update) {
+        this.lines.add(index, line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void insertLine(int index, String line) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+    }
+
+    @Override
+    public void insertLine(int index, String line, boolean update) {
+        this.lines.remove(index);
+        this.lines.add(index, new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(IHoloLine line, boolean update) {
+        this.lines.add(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void addLine(String line) {
+        this.lines.add(new HoloLine(line, this));
+    }
+
+    @Override
+    public void addLine(String line, boolean update) {
+        this.lines.add(new HoloLine(line, this));
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(IHoloLine line, boolean update) {
+        this.lines.remove(line);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void removeLine(int index, boolean update) {
+        this.lines.remove(index);
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void clearLines(boolean update) {
+        this.lines.clear();
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public void setGap(double gap) {
+        this.gap = gap;
+        this.update();
+    }
+
+    @Override
+    public void setGap(double gap, boolean update) {
+        this.gap = gap;
+        if (update) {
+            this.update();
+        }
+    }
+
+    @Override
+    public double getGap() {
+        return this.gap;
+    }
+
+    @Override
+    public void remove() {
+        for (IHoloLine line : this.lines) line.remove();
+        lines.clear();
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
@@ -1,0 +1,947 @@
+/*
+ * BedWars2023 - A bed wars mini-game.
+ * Copyright (C) 2024 Tomas Keuper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: contact@fyreblox.com
+ */
+
+package com.tomkeuper.bedwars.support.version.v1_21_R7;
+
+import com.mojang.datafixers.util.Pair;
+import com.saicone.rtag.RtagItem;
+import com.saicone.rtag.util.OptionalType;
+import com.saicone.rtag.util.SkullTexture;
+import com.tomkeuper.bedwars.api.arena.IArena;
+import com.tomkeuper.bedwars.api.arena.generator.IGeneratorAnimation;
+import com.tomkeuper.bedwars.api.arena.shop.ShopHolo;
+import com.tomkeuper.bedwars.api.arena.team.ITeam;
+import com.tomkeuper.bedwars.api.arena.team.TeamColor;
+import com.tomkeuper.bedwars.api.entity.Despawnable;
+import com.tomkeuper.bedwars.api.entity.GeneratorHolder;
+import com.tomkeuper.bedwars.api.events.player.PlayerKillEvent;
+import com.tomkeuper.bedwars.api.hologram.containers.IHoloLine;
+import com.tomkeuper.bedwars.api.hologram.containers.IHologram;
+import com.tomkeuper.bedwars.api.language.Language;
+import com.tomkeuper.bedwars.api.language.Messages;
+import com.tomkeuper.bedwars.api.server.VersionSupport;
+import com.tomkeuper.bedwars.support.version.common.VersionCommon;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable.DespawnableAttributes;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable.DespawnableFactory;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.despawnable.DespawnableType;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.hologram.HoloLine;
+import com.tomkeuper.bedwars.support.version.v1_21_R7.hologram.Hologram;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.core.particles.ParticleParamRedstone;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.EntityReference;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.decoration.EntityArmorStand;
+import net.minecraft.world.entity.item.EntityTNTPrimed;
+import net.minecraft.world.entity.projectile.IProjectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBase;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Ladder;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.v1_21_R7.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R7.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R7.entity.*;
+import org.bukkit.craftbukkit.v1_21_R7.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_21_R7.util.CraftMagicNumbers;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.*;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.logging.Level;
+
+public final class v1_21_R7 extends VersionSupport {
+
+    private final DespawnableFactory despawnableFactory;
+
+    public v1_21_R7(Plugin plugin, String name) {
+        super(plugin, name);
+        loadDefaultEffects();
+        this.despawnableFactory = new DespawnableFactory(this);
+    }
+
+    @Override
+    public void registerCommand(String name, Command cmd) {
+        ((CraftServer) getPlugin().getServer()).getCommandMap().register(name, cmd);
+    }
+
+    @Override
+    public void sendTitle(Player p, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
+    }
+
+    @Override
+    public void playAction(Player p, String text) {
+        p.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.translateAlternateColorCodes('&', text)
+                )
+        );
+    }
+
+    @Override
+    public boolean isBukkitCommandRegistered(String name) {
+        return ((CraftServer) getPlugin().getServer()).getCommandMap().getCommand(name) != null;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemInHand(@NotNull Player p) {
+        return p.getInventory().getItemInMainHand();
+    }
+
+    @Override
+    public void hideEntity(Entity e, Player p) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(e.getEntityId());
+        sendPacket(p, packet);
+    }
+
+    @Override
+    public void fakeDamagePlayer(Player e) {
+        Location loc = e.getLocation();
+        World world = e.getWorld();
+        world.playSound(loc, Sound.ENTITY_PLAYER_HURT, 1.0f, 1.0f);
+        PacketPlayOutAnimation anim = new PacketPlayOutAnimation(((CraftPlayer) e).getHandle(), 1);
+        for (Player p : e.getWorld().getPlayers()) {
+            sendPackets(p, anim);
+        }
+    }
+
+    @Override
+    public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return Tag.ITEMS_HEAD_ARMOR.isTagged(itemStack.getType()) || Tag.ITEMS_CHEST_ARMOR.isTagged(itemStack.getType())
+                || Tag.ITEMS_LEG_ARMOR.isTagged(itemStack.getType()) || Tag.ITEMS_FOOT_ARMOR.isTagged(itemStack.getType()) || itemStack.getType() == materialElytra();
+    }
+
+    @Override
+    public boolean isTool(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return itemStack.hasItemMeta();
+    }
+
+    @Override
+    public boolean isSword(org.bukkit.inventory.ItemStack itemStack) {
+        if(itemStack == null)
+            return false;
+
+        return Tag.ITEMS_SWORDS.isTagged(itemStack.getType());
+    }
+
+    @Override
+    public boolean isAxe(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemAxe;
+    }
+
+    @Override
+    public boolean isBow(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemBow;
+    }
+
+
+    @Override
+    public boolean isProjectile(org.bukkit.inventory.ItemStack itemStack) {
+        var entity = getEntity(itemStack);
+        if (null == entity) return false;
+        return entity instanceof IProjectile;
+    }
+
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.@NotNull ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
+    public void registerEntities() {
+
+    }
+
+    @Override
+    public void spawnShop(Location loc, String name1, Iterable<Player> players, IArena arena) {
+        Location l = loc.clone();
+
+        if (l.getWorld() == null) return;
+        Villager vlg = (Villager) l.getWorld().spawnEntity(loc, EntityType.VILLAGER);
+        vlg.setAI(false);
+        vlg.setRemoveWhenFarAway(false);
+        vlg.setCollidable(false);
+        vlg.setInvulnerable(true);
+        vlg.setSilent(true);
+    }
+
+    @Override
+    public void spawnShopHologram(Location loc, String name1, Iterable<Player> players, ITeam team) {
+        HashMap<String, List<Player>> languagePlayers = new HashMap<>();
+
+        for (Player p : players) {
+            String iso = Language.getPlayerLanguage(p).getIso();
+            if (!languagePlayers.containsKey(iso)) languagePlayers.put(iso, new ArrayList<>());
+            languagePlayers.get(iso).add(p);
+        }
+
+        for (String iso : languagePlayers.keySet()) {
+            Language lang = Language.getLang(iso);
+            String[] text = (lang.l(name1) == null || lang.l(name1).isEmpty() ? lang.l(name1.replace(name1.split("\\.")[2], "default")) : lang.l(name1)).toArray(new String[0]);
+            IHologram h = createHologram(languagePlayers.get(iso), loc, text);
+            new ShopHolo(h, team, iso);
+        }
+    }
+
+    @Override
+    public double getDamage(org.bukkit.inventory.ItemStack i) {
+        var tag = getTag(i);
+        if (null == tag) {
+            throw new RuntimeException("Provided item has no Tag");
+        }
+        return tag.b("generic.attackDamage", 0);
+    }
+
+    @Override
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage, int pathFindingTicks) {
+        var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
+
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH
+        );
+    }
+
+    @Override
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, int pathFindingTicks) {
+        var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam, pathFindingTicks);
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM
+        );
+    }
+
+    @Override
+    public void minusAmount(Player p, org.bukkit.inventory.@NotNull ItemStack i, int amount) {
+        if (i.getAmount() - amount <= 0) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
+            return;
+        }
+        i.setAmount(i.getAmount() - amount);
+        //noinspection UnstableApiUsage
+        p.updateInventory();
+    }
+
+    @Override
+    public void setSource(TNTPrimed tnt, Player owner) {
+        EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
+        EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
+        nmsTNT.j = nmsEntityLiving != null ? EntityReference.a(nmsEntityLiving) : null;
+    }
+
+    @Override
+    public void voidKill(Player p) {
+        p.damage(1000.0);
+    }
+
+    @Override
+    public void hideArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public void showArmor(Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(victim.getInventory().getHelmet())));
+        items.add(new Pair<>(EnumItemSlot.e, CraftItemStack.asNMSCopy(victim.getInventory().getChestplate())));
+        items.add(new Pair<>(EnumItemSlot.d, CraftItemStack.asNMSCopy(victim.getInventory().getLeggings())));
+        items.add(new Pair<>(EnumItemSlot.c, CraftItemStack.asNMSCopy(victim.getInventory().getBoots())));
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet);
+    }
+
+    @Override
+    public EnderDragon spawnDragon(Location l, ITeam team) {
+        if (l == null || l.getWorld() == null) {
+            getPlugin().getLogger().log(Level.WARNING, "Could not spawn Dragon. Location is null");
+            return null;
+        }
+        EnderDragon ed = (EnderDragon) l.getWorld().spawnEntity(l, EntityType.ENDER_DRAGON);
+        ed.setPhase(EnderDragon.Phase.CIRCLING);
+        return ed;
+    }
+
+    @Override
+    public void colorBed(ITeam bwt) {
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
+                if (bed instanceof Bed) {
+                    bed.setType(bwt.getColor().bedMaterial());
+                    bed.update();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
+        try {
+            // blast resistance
+            Field field = BlockBase.class.getDeclaredField("explosionResistance");
+            field.setAccessible(true);
+            // end stone
+            field.set(Blocks.go, endStoneBlast);
+            // obsidian
+            field.set(Blocks.cK, glassBlast);
+            // standard glass
+            field.set(Blocks.aX, glassBlast);
+
+            var coloredGlass = new net.minecraft.world.level.block.Block[]{
+                    Blocks.ez, Blocks.eA, Blocks.eB, Blocks.eC,
+                    Blocks.eD, Blocks.eE, Blocks.eF, Blocks.eG,
+                    Blocks.eH, Blocks.eI, Blocks.eJ, Blocks.eK,
+                    Blocks.eL, Blocks.eM, Blocks.eN, Blocks.eO,
+
+                    Blocks.aX,
+            };
+
+            Arrays.stream(coloredGlass).forEach(
+                    glass -> {
+                        try {
+                            field.set(glass, glassBlast);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            //noinspection CallToPrintStackTrace
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public float getBlastResistance(org.bukkit.block.Block bukkitBlock) {
+        try {
+            // Convert Bukkit block to NMS Block
+            net.minecraft.world.level.block.Block nmsBlock = CraftMagicNumbers.getBlock(bukkitBlock.getType());
+
+            // Access the 'durability' field
+            Field durabilityField = BlockBase.class.getDeclaredField("explosionResistance");
+            durabilityField.setAccessible(true);
+
+            return durabilityField.getFloat(nmsBlock);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return 0; // Default if something fails
+    }
+
+    @Override
+    public void setBlockTeamColor(Block block, TeamColor teamColor) {
+        if (block.getType().toString().contains("STAINED_GLASS") || block.getType().toString().equals("GLASS")) {
+            block.setType(teamColor.glassMaterial());
+        } else if (block.getType().toString().contains("_TERRACOTTA")) {
+            block.setType(teamColor.glazedTerracottaMaterial());
+        } else if (block.getType().toString().contains("_WOOL")) {
+            block.setType(teamColor.woolMaterial());
+        }
+    }
+
+    @Override
+    public void setCollide(Player p, IArena a, boolean value) {
+        p.setCollidable(value);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addCustomData(org.bukkit.inventory.ItemStack i, String data) {
+        return RtagItem.edit(i, tag -> {
+            tag.set(data, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        });
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {
+        return RtagItem.edit(itemStack, tag -> {
+            tag.set(value, key);
+        });
+    }
+
+    @Override
+    public String getTag(org.bukkit.inventory.ItemStack itemStack, String key) {
+        var tag = getTag(itemStack);
+        return tag == null ? null : tag.b(key) ? tag.b(key, null) : null;
+    }
+
+    @Override
+    public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        if (i == null) return false;
+        if (i.getType() == org.bukkit.Material.AIR) return false;
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return tag.isNotEmpty();
+    }
+
+    @Override
+    public String getCustomData(org.bukkit.inventory.ItemStack i) {
+        RtagItem rtagItem = new RtagItem(i);
+        OptionalType tag = rtagItem.getOptional(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+        return (tag.isEmpty() || tag.isNotInstance(String.class)) ? null : tag.asString(null);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack colourItem(org.bukkit.inventory.ItemStack itemStack, ITeam bedWarsTeam) {
+        if (itemStack == null) return null;
+        String type = itemStack.getType().toString();
+        if (isBed(itemStack.getType())) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().bedMaterial(), itemStack.getAmount());
+        } else if (type.contains("_STAINED_GLASS_PANE")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassPaneMaterial(), itemStack.getAmount());
+        } else if (type.contains("STAINED_GLASS") || type.equals("GLASS")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassMaterial(), itemStack.getAmount());
+        } else if (type.contains("_TERRACOTTA")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glazedTerracottaMaterial(), itemStack.getAmount());
+        } else if (type.contains("_WOOL")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().woolMaterial(), itemStack.getAmount());
+        }
+        return itemStack;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack createItemStack(String material, int amount, short data) {
+        org.bukkit.inventory.ItemStack i;
+        try {
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.valueOf(material), amount);
+        } catch (Exception ex) {
+            getPlugin().getLogger().log(Level.WARNING, material + " is not a valid " + getName() + " material!");
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.BEDROCK);
+        }
+        return i;
+    }
+
+    @Override
+    public Material materialFireball() {
+        return org.bukkit.Material.FIRE_CHARGE;
+    }
+
+    @Override
+    public org.bukkit.Material materialPlayerHead() {
+        return org.bukkit.Material.PLAYER_HEAD;
+    }
+
+    @Override
+    public org.bukkit.Material materialSnowball() {
+        return org.bukkit.Material.SNOWBALL;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenHelmet() {
+        return org.bukkit.Material.GOLDEN_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenChestPlate() {
+        return org.bukkit.Material.GOLDEN_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenLeggings() {
+        return org.bukkit.Material.GOLDEN_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteHelmet() {
+        return Material.NETHERITE_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteChestPlate() {
+        return Material.NETHERITE_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteLeggings() {
+        return Material.NETHERITE_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialElytra() {
+        return Material.ELYTRA;
+    }
+
+    @Override
+    public org.bukkit.Material materialCake() {
+        return org.bukkit.Material.CAKE;
+    }
+
+    @Override
+    public org.bukkit.Material materialCraftingTable() {
+        return org.bukkit.Material.CRAFTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEnchantingTable() {
+        return org.bukkit.Material.ENCHANTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEndStone() {
+        return Material.END_STONE;
+    }
+
+    @Override
+    public org.bukkit.Material woolMaterial() {
+        return org.bukkit.Material.WHITE_WOOL;
+    }
+
+    @Override
+    public void setJoinSignBackground(BlockState b, Material material) {
+        if (b.getBlockData() instanceof WallSign) {
+            b.getBlock().getRelative(((WallSign) b.getBlockData()).getFacing().getOppositeFace()).setType(material);
+        }
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack redGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.RED_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack greenGlassPane(int amount) {
+        return new org.bukkit.inventory.ItemStack(Material.LIME_STAINED_GLASS_PANE, amount);
+    }
+
+    @Override
+    public String getShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem item = new RtagItem(itemStack);
+        OptionalType tag = item.getOptional(VersionSupport.PLUGIN_TAG_TIER_KEY);
+        return tag.isEmpty() ? "null" : tag.asString("null");
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack, String identifier) {
+        RtagItem item = new RtagItem(itemStack);
+        item.set(identifier, VersionSupport.PLUGIN_TAG_TIER_KEY);
+        item.load();
+        return item.getItem();
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getPlayerHead(Player player, org.bukkit.inventory.ItemStack copyTagFrom) {
+        org.bukkit.inventory.ItemStack head = SkullTexture.getTexturedHead(player.getUniqueId().toString());
+
+        if (copyTagFrom != null) {
+            var tag = getTag(copyTagFrom);
+            RtagItem rtagItem = new RtagItem(head);
+            rtagItem.set(tag, VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+            rtagItem.load();
+            head = rtagItem.getItem();
+        }
+
+        return head;
+    }
+
+    @Override
+    public void sendPlayerSpawnPackets(Player respawned, IArena arena) {
+        if (respawned == null) return;
+        if (arena == null) return;
+        if (!arena.isPlayer(respawned)) return;
+
+        // if method was used when the player was still in re-spawning screen
+        if (arena.getRespawnSessions().containsKey(respawned)) return;
+
+        EntityPlayer entityPlayer = getPlayer(respawned);
+        PacketPlayOutSpawnEntity show = newPacketPlayOutSpawnEntity(entityPlayer);
+        PacketPlayOutEntityVelocity playerVelocity = new PacketPlayOutEntityVelocity(entityPlayer);
+        // we send head rotation packet because sometimes on respawn others see him with bad rotation
+        PacketPlayOutEntityHeadRotation head = new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()));
+
+        // retrieve current armor and in-hand items
+        // we send a packet later for timing issues where other players do not see them
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = getPlayerEquipment(entityPlayer);
+
+
+        for (Player p : arena.getPlayers()) {
+            if (p == null) continue;
+            if (p.equals(respawned)) continue;
+            // if p is in re-spawning screen continue
+            if (arena.getRespawnSessions().containsKey(p)) continue;
+
+            EntityPlayer boundTo = getPlayer(p);
+            if (p.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(p.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to regular players
+                    sendPackets(
+                            p, show, head, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list)
+                    );
+
+                    // send nearby players to respawned player
+                    // if the player has invisibility hide armor
+                    if (p.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                        hideArmor(p, respawned);
+                    } else {
+                        PacketPlayOutSpawnEntity show2 = newPacketPlayOutSpawnEntity(boundTo);
+
+                        PacketPlayOutEntityVelocity playerVelocity2 = new PacketPlayOutEntityVelocity(boundTo);
+                        PacketPlayOutEntityHeadRotation head2 = new PacketPlayOutEntityHeadRotation(boundTo, getCompressedAngle(boundTo.getBukkitYaw()));
+                        sendPackets(respawned, show2, playerVelocity2, head2);
+                        showArmor(p, respawned);
+                    }
+                }
+            }
+        }
+
+        for (Player spectator : arena.getSpectators()) {
+            if (spectator == null) continue;
+            if (spectator.equals(respawned)) continue;
+            respawned.hidePlayer(getPlugin(), spectator);
+            if (spectator.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(spectator.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to spectator
+                    sendPackets(
+                            spectator, show, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list),
+                            new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()))
+                    );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getInventoryName(@NotNull InventoryEvent e) {
+        return e.getView().getTitle();
+    }
+
+    @Override
+    public void setUnbreakable(ItemMeta itemMeta) {
+        itemMeta.setUnbreakable(true);
+    }
+
+    @Override
+    public int getVersion() {
+        return 14;
+    }
+
+    @Override
+    public void registerVersionListeners() {
+        new VersionCommon(this);
+    }
+
+    @Override
+    public String getMainLevel() {
+        //noinspection deprecation
+        return ((DedicatedServer) MinecraftServer.getServer()).a().o;
+    }
+
+    @Override
+    public Fireball setFireballDirection(Fireball fireball, Vector vector) {
+        fireball.setDirection(vector);
+        return fireball;
+    }
+
+    @Override
+    public void playRedStoneDot(Player player) {
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                ParticleParamRedstone.b,
+                true,
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player p : player.getWorld().getPlayers()) {
+            if (p.equals(player)) continue;
+            sendPacket(p, particlePacket);
+        }
+    }
+
+    @Override
+    public void clearArrowsFromPlayerBody(Player player) {
+        // minecraft clears them on death on newer version
+    }
+
+    @Override
+    public Block placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
+        b.getRelative(x, y, z).setType(color.woolMaterial());
+        a.addPlacedBlock(b.getRelative(x, y, z));
+        return b.getRelative(x, y, z);
+    }
+
+    @Override
+    public Block placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
+        Block block = b.getRelative(x, y, z);  //ladder block
+        block.setType(Material.LADDER);
+        if(block.getBlockData() instanceof Ladder ladder) {
+            a.addPlacedBlock(block);
+            switch (ladderData) {
+                case 2 -> {
+                    ladder.setFacing(BlockFace.NORTH);
+                    block.setBlockData(ladder);
+                }
+                case 3 -> {
+                    ladder.setFacing(BlockFace.SOUTH);
+                    block.setBlockData(ladder);
+                }
+                case 4 -> {
+                    ladder.setFacing(BlockFace.WEST);
+                    block.setBlockData(ladder);
+                }
+                case 5 -> {
+                    ladder.setFacing(BlockFace.EAST);
+                    block.setBlockData(ladder);
+                }
+            }
+        }
+        return b;
+    }
+
+    @Override
+    public void playVillagerEffect(Player player, Location location) {
+        player.spawnParticle(Particle.HAPPY_VILLAGER, location, 1);
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, location, linesList);
+    }
+
+    @Override
+    public IHologram createHologram(Player p, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(p, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(Iterable<Player> players, Location location, String... lines) {
+        List<String> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, linesList, location);
+    }
+
+    @Override
+    public IHologram createHologram(Iterable<Player> players, Location location, IHoloLine... lines) {
+        List<IHoloLine> linesList = new ArrayList<>(Arrays.asList(lines));
+        // holograms are reversed, correcting that here
+        Collections.reverse(linesList);
+        return new Hologram(players, location, linesList);
+    }
+
+    @Override
+    public IHoloLine lineFromText(String text, @NotNull IHologram hologram) {
+        return new HoloLine(text, hologram);
+    }
+
+    @Override
+    public IGeneratorAnimation createDefaultGeneratorAnimation(ArmorStand armorStand) {
+        return new DefaultGenAnimation(armorStand);
+    }
+
+    @Override
+    public void updatePacketArmorStand(GeneratorHolder gh, Iterable<Player> players) {
+        ArmorStand armorStand = gh.getArmorStand();
+        EntityArmorStand nmsEntity = ((CraftArmorStand) armorStand).getHandle();
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().aD().c());
+        Pair<EnumItemSlot, net.minecraft.world.item.ItemStack> equip = new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(gh.getHelmet()));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), Collections.singletonList(equip));
+
+        for (Player p : players) {
+            sendPackets(p, spawn, metadata, equipment);
+        }
+    }
+
+    @Override
+    public void updatePacketArmorStandEquipment(GeneratorHolder generatorHolder) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        World world = armorStand.getWorld();
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(generatorHolder.getHelmet())));
+        PacketPlayOutEntityEquipment equipment = new PacketPlayOutEntityEquipment(armorStand.getEntityId(), items);
+        PacketPlayOutEntityMetadata metadata = new PacketPlayOutEntityMetadata(armorStand.getEntityId(), ((CraftArmorStand) armorStand).getHandle().aD().c());
+        for (Player p : world.getPlayers()) {
+            sendPackets(p, equipment, metadata);
+        }
+    }
+
+    @Override
+    public void callPlayerDeathEvent(Player player, List<org.bukkit.inventory.ItemStack> drops, int droppedExp, int newLevel, String deathMessage) {
+        DamageSource ds = DamageSource.builder(DamageType.GENERIC).build();
+        PlayerDeathEvent deathEvent = new PlayerDeathEvent(player, ds, drops, droppedExp, newLevel, deathMessage);
+        Bukkit.getPluginManager().callEvent(deathEvent);
+    }
+
+    @Override
+    public float getAbsorption(Player player) {
+        return (float) player.getAbsorptionAmount();
+    }
+
+    @Override
+    public void destroyPacketArmorStand(GeneratorHolder generatorHolder, Iterable<Player> players) {
+        ArmorStand armorStand = generatorHolder.getArmorStand();
+        PacketPlayOutEntityDestroy destroy = new PacketPlayOutEntityDestroy(armorStand.getEntityId());
+        for (Player p : players) {
+            sendPacket(p, destroy);
+        }
+    }
+
+    @Override
+    public ArmorStand createPacketArmorStand(Location loc, Iterable<Player> players) {
+        if (loc.getWorld() == null) throw new RuntimeException("World of a location should not be null.");
+        EntityArmorStand nmsEntity = new EntityArmorStand(((CraftWorld) loc.getWorld()).getHandle(), loc.getX(), loc.getY(), loc.getZ());
+        nmsEntity.a_(loc.getX(), loc.getY(), loc.getZ());
+        PacketPlayOutSpawnEntity spawn = newPacketPlayOutSpawnEntity(nmsEntity);
+
+        for (Player p : players) {
+            sendPacket(p, spawn);
+        }
+        return new CraftArmorStand((CraftServer) getPlugin().getServer(), nmsEntity);
+    }
+
+    public static void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().g.b(packet);
+    }
+
+    public static void sendPackets(Player player, Packet<?> @NotNull ... packets) {
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().g;
+        for (Packet<?> p : packets) {
+            connection.b(p);
+        }
+    }
+
+    /**
+     * Gets the NMS Item from ItemStack
+     */
+    private @Nullable Item getItem(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.h();
+    }
+
+    /**
+     * Gets the NMS Entity from ItemStack
+     */
+    private @Nullable net.minecraft.world.entity.Entity getEntity(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.J();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
+        RtagItem rtagItem = new RtagItem(itemStack);
+        return (NBTTagCompound) rtagItem.getTag();
+    }
+
+    public EntityPlayer getPlayer(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    public List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> getPlayerEquipment(@NotNull EntityPlayer entityPlayer) {
+        List<Pair<EnumItemSlot, net.minecraft.world.item.ItemStack>> list = new ArrayList<>();
+        list.add(new Pair<>(EnumItemSlot.a, entityPlayer.a(EnumItemSlot.a)));
+        list.add(new Pair<>(EnumItemSlot.b, entityPlayer.a(EnumItemSlot.b)));
+        list.add(new Pair<>(EnumItemSlot.f, entityPlayer.a(EnumItemSlot.f)));
+        list.add(new Pair<>(EnumItemSlot.e, entityPlayer.a(EnumItemSlot.e)));
+        list.add(new Pair<>(EnumItemSlot.d, entityPlayer.a(EnumItemSlot.d)));
+        list.add(new Pair<>(EnumItemSlot.c, entityPlayer.a(EnumItemSlot.c)));
+
+        return list;
+    }
+
+    public static PacketPlayOutSpawnEntity newPacketPlayOutSpawnEntity(net.minecraft.world.entity.Entity nmsEntity) {
+        return new PacketPlayOutSpawnEntity(
+                nmsEntity.aA(),
+                nmsEntity.cY(),
+                nmsEntity.dP(),
+                nmsEntity.dR(),
+                nmsEntity.dV(),
+                nmsEntity.ee(),
+                nmsEntity.ec(),
+                nmsEntity.ay(),
+                0,
+                nmsEntity.dN(),
+                nmsEntity.cS()
+        );
+    }
+}

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
@@ -337,15 +337,43 @@ public final class v1_21_R7 extends VersionSupport {
     }
 
     @Override
-    public void colorBed(ITeam bwt) {
+    public void colorBed(ITeam team) {
         for (int x = -1; x <= 1; x++) {
             for (int z = -1; z <= 1; z++) {
-                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
-                if (bed instanceof Bed) {
-                    bed.setType(bwt.getColor().bedMaterial());
-                    bed.update();
+                Location bedLoc = team.getBed().clone().add(x, 0, z);
+                Block bedBlock = bedLoc.getBlock();
+                BlockState blockState = bedBlock.getState();
+
+                if (blockState.getBlockData() instanceof Bed bedData) {
+                    Material bedMaterial = team.getColor().bedMaterial();
+                    if (bedMaterial == null) continue;
+
+                    // Identify head and foot parts
+                    Block headPart;
+                    Block footPart;
+
+                    if (bedData.getPart() == Bed.Part.HEAD) {
+                        headPart = bedBlock;
+                        footPart = bedBlock.getRelative(bedData.getFacing().getOppositeFace());
+                    } else {
+                        footPart = bedBlock;
+                        headPart = bedBlock.getRelative(bedData.getFacing());
+                    }
+
+                    // Update both parts
+                    updateBedBlock(headPart, bedMaterial, bedData.getFacing(), Bed.Part.HEAD);
+                    updateBedBlock(footPart, bedMaterial, bedData.getFacing(), Bed.Part.FOOT);
                 }
             }
+        }
+    }
+
+    private void updateBedBlock(Block block, Material material, BlockFace facing, Bed.Part part) {
+        block.setType(material, false);
+        if (block.getBlockData() instanceof Bed bed) {
+            bed.setFacing(facing);
+            bed.setPart(part);
+            block.setBlockData(bed, true);
         }
     }
 

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
@@ -363,10 +363,10 @@ public final class v1_21_R7 extends VersionSupport {
             field.set(Blocks.aX, glassBlast);
 
             var coloredGlass = new net.minecraft.world.level.block.Block[]{
-                    Blocks.ez, Blocks.eA, Blocks.eB, Blocks.eC,
-                    Blocks.eD, Blocks.eE, Blocks.eF, Blocks.eG,
-                    Blocks.eH, Blocks.eI, Blocks.eJ, Blocks.eK,
-                    Blocks.eL, Blocks.eM, Blocks.eN, Blocks.eO,
+                    Blocks.eN, Blocks.eO, Blocks.eP, Blocks.eQ,
+                    Blocks.eR, Blocks.eS, Blocks.eT, Blocks.eU,
+                    Blocks.eV, Blocks.eW, Blocks.eX, Blocks.eY,
+                    Blocks.eZ, Blocks.fa, Blocks.fb, Blocks.fc,
 
                     Blocks.aX,
             };

--- a/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
+++ b/versionsupport_v1_21_r7/src/main/java/com/tomkeuper/bedwars/support/version/v1_21_R7/v1_21_R7.java
@@ -67,6 +67,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.block.data.type.Ladder;
 import org.bukkit.block.data.type.WallSign;
@@ -338,42 +339,25 @@ public final class v1_21_R7 extends VersionSupport {
 
     @Override
     public void colorBed(ITeam team) {
+        Location bedLoc = team.getBed();
+        if (bedLoc == null) return;
+        Material bedMaterial = team.getColor().bedMaterial();
+        if (bedMaterial == null) return;
         for (int x = -1; x <= 1; x++) {
             for (int z = -1; z <= 1; z++) {
-                Location bedLoc = team.getBed().clone().add(x, 0, z);
-                Block bedBlock = bedLoc.getBlock();
-                BlockState blockState = bedBlock.getState();
-
-                if (blockState.getBlockData() instanceof Bed bedData) {
-                    Material bedMaterial = team.getColor().bedMaterial();
-                    if (bedMaterial == null) continue;
-
-                    // Identify head and foot parts
-                    Block headPart;
-                    Block footPart;
-
-                    if (bedData.getPart() == Bed.Part.HEAD) {
-                        headPart = bedBlock;
-                        footPart = bedBlock.getRelative(bedData.getFacing().getOppositeFace());
-                    } else {
-                        footPart = bedBlock;
-                        headPart = bedBlock.getRelative(bedData.getFacing());
-                    }
-
-                    // Update both parts
-                    updateBedBlock(headPart, bedMaterial, bedData.getFacing(), Bed.Part.HEAD);
-                    updateBedBlock(footPart, bedMaterial, bedData.getFacing(), Bed.Part.FOOT);
+                Block bedBlock = bedLoc.clone().add(x, 0, z).getBlock();
+                BlockData blockData = bedBlock.getBlockData();
+                if (!(blockData instanceof org.bukkit.block.data.type.Bed)) continue;
+                BlockFace facing = ((org.bukkit.block.data.type.Bed) blockData).getFacing();
+                org.bukkit.block.data.type.Bed.Part part = ((org.bukkit.block.data.type.Bed) blockData).getPart();
+                bedBlock.setType(bedMaterial, false);
+                blockData = bedBlock.getBlockData();
+                if (blockData instanceof org.bukkit.block.data.type.Bed bed) {
+                    bed.setFacing(facing);
+                    bed.setPart(part);
+                    bedBlock.setBlockData(bed, false);
                 }
             }
-        }
-    }
-
-    private void updateBedBlock(Block block, Material material, BlockFace facing, Bed.Part part) {
-        block.setType(material, false);
-        if (block.getBlockData() instanceof Bed bed) {
-            bed.setFacing(facing);
-            bed.setPart(part);
-            block.setBlockData(bed, true);
         }
     }
 


### PR DESCRIPTION
## 🧾 Basic Information

- **Minecraft Version**: 1.21.11
- **NMS Version Targeted**: net.minecraft.server.v1_21_R7
- **Related Issues / Discussions**: <!-- Optional -->

---

## 🧠 Description of Change

With a little help from AI of course (finding the correct mappings), support was added to the version detailed above.

---

## ✅ Admission Tests

### Regular
- [X] Cannot drop default wooden sword
- [X] Cannot break own bed
- [X] Cannot remove armor
- [X] Can break player-placed blocks
- [X] Cannot place blocks in team-spawn region
- [X] Cannot damage shopkeepers
- [X] Shopkeepers immune to Silverfishes/Iron Golems
- [X] Cannot be targeted by own Silverfishes/Iron Golems
- [x] Shopkeepers immune to Explosions

### Console
- [x] No errors when placing TNT
- [x] No errors when respawning players
- [x] No errors on server startup
- [x] No errors during regular match

### Visual
- [x] TNT Spoil shows RED particles above head
- [X] Team upgrades announced in chat
- [x] Invisible to others during respawn phase

### Blast Protection
- [x] Regular Glass is blast-resistant
- [x] Colored Glass is blast-resistant
- [x] Obsidian is blast-resistant
- [x] Endstone (Fireball) resists blasts
- [x] Wool covered with Glass or Stained Glass does not explode

---

## 🛠️ NMS Update Checklist

- [x] Previously inaccessible fields now accessible? (reflective → direct access)
---

## 📰 Release Notes

<!-- Short, user-facing summary of this NMS change -->

