### PR TITLE
Fix 1.16 compatibility issues 

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/BedWars.java
@@ -108,9 +108,12 @@ import de.dytanic.cloudnet.wrapper.Wrapper;
 import io.github.slimjar.app.builder.ApplicationBuilder;
 import me.neznamy.tab.api.TabAPI;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.*;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
@@ -308,7 +311,12 @@ public class BedWars extends JavaPlugin {
             return;
         }
 
-        this.adventure = BukkitAudiences.create(this);
+        if (Objects.equals(getServerVersion(), "v1_16_R3")) {
+            // Do not initialize BukkitAudiences on 1.16
+            this.adventure = null;
+        } else {
+            this.adventure = BukkitAudiences.create(this);
+        }
 
         nms.registerVersionListeners();
 
@@ -1245,5 +1253,15 @@ public class BedWars extends JavaPlugin {
 
     public BukkitAudiences adventure() {
         return this.adventure;
+    }
+
+    public void sendMessage(CommandSender sender, Component component) {
+        if (this.adventure != null) {
+            this.adventure.sender(sender).sendMessage(component);
+        } else {
+            sender.sendMessage(
+                    LegacyComponentSerializer.legacySection().serialize(component)
+            );
+        }
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -490,7 +490,7 @@ public class Arena implements IArena {
         if (getPartyManager().hasParty(p)) {
             if (!skipOwnerCheck) {
                 if (!getPartyManager().isOwner(p)) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_NOT_PARTY_LEADER)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_NOT_PARTY_LEADER)));
                     return false;
                 }
                 int partySize = (int) getPartyManager().getMembers(p).stream().filter(member -> {
@@ -502,7 +502,7 @@ public class Arena implements IArena {
                 }).count();
 
                 if (partySize > maxInTeam * getTeams().size() - getPlayers().size()) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_PARTY_TOO_BIG)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_PARTY_TOO_BIG)));
                     return false;
                 }
                 for (Player mem : new ArrayList<>(getPartyManager().getMembers(p))) {
@@ -543,7 +543,7 @@ public class Arena implements IArena {
                     }
                 }
                 if (!canJoin) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_IS_FULL_OF_VIPS)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_DENIED_IS_FULL_OF_VIPS)));
                     return false;
                 }
             }
@@ -566,7 +566,7 @@ public class Arena implements IArena {
             for (Player on : players) {
                 Language language = Language.getPlayerLanguage(on);
                 if (ev.getMessage().equals("")) {
-                    BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_JOIN_PLAYER_JOIN_MSG)
+                    BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_JOIN_PLAYER_JOIN_MSG)
                             .replace("%bw_v_prefix%", getChatSupport().getPrefix(p))
                             .replace("%bw_v_suffix%", getChatSupport().getSuffix(p))
                             .replace("%bw_playername%", p.getName())
@@ -576,7 +576,7 @@ public class Arena implements IArena {
                     );
                 } else {
                     if (ev.getMessage() != null)
-                        BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(ev.getMessage()));
+                        BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(ev.getMessage()));
                 }
             }
             setArenaByPlayer(p, this);
@@ -790,8 +790,7 @@ public class Arena implements IArena {
 
             leaving.remove(p);
 
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_MSG).replace("%bw_arena%", this.getDisplayName())));
-
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_MSG).replace("%bw_arena%", this.getDisplayName())));
             /* update generator holograms for spectators */
             for (IGenerator o : getOreGenerators()) {
                 o.updateHolograms(p);
@@ -806,7 +805,7 @@ public class Arena implements IArena {
             }
 
         } else {
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_DENIED_MSG)));
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_DENIED_MSG)));
             return false;
         }
 
@@ -892,7 +891,7 @@ public class Arena implements IArena {
         if (status == GameState.starting && (maxInTeam > players.size() && teamuri || players.size() < minPlayers && !teamuri)) {
             changeStatus(GameState.waiting);
             for (Player on : players) {
-                BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(on, Messages.ARENA_START_COUNTDOWN_STOPPED_INSUFF_PLAYERS_CHAT)));
+                BedWars.plugin.sendMessage(on,ChatFormatting.parseLegacyMini(getMsg(on, Messages.ARENA_START_COUNTDOWN_STOPPED_INSUFF_PLAYERS_CHAT)));
             }
         } else if (status == GameState.playing) {
             int alive_teams = 0;
@@ -908,11 +907,11 @@ public class Arena implements IArena {
                 if (team != null) {
                     if (!team.isBedDestroyed()) {
                         for (Player p2 : this.getPlayers()) {
-                            BedWars.plugin.adventure().player(p2).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", team.getColor().chat().toString())
+                            BedWars.plugin.sendMessage(p2, ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", team.getColor().chat().toString())
                                     .replace("%bw_team_name%", team.getDisplayName(Language.getPlayerLanguage(p2)))));
                         }
                         for (Player p2 : this.getSpectators()) {
-                            BedWars.plugin.adventure().player(p2).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", team.getColor().chat().toString())
+                            BedWars.plugin.sendMessage(p2, ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", team.getColor().chat().toString())
                                     .replace("%bw_team_name%", team.getDisplayName(Language.getPlayerLanguage(p2)))));
                         }
                     }
@@ -940,7 +939,7 @@ public class Arena implements IArena {
                     PlayerKillEvent event = new PlayerKillEvent(this, p, lastDamager, player -> Language.getMsg(player, message), cause);
                     for (Player inGame : getPlayers()) {
                         Language lang = Language.getPlayerLanguage(inGame);
-                        BedWars.plugin.adventure().player(inGame).sendMessage(ChatFormatting.parseLegacyMini(event.getMessage().apply(inGame)
+                        BedWars.plugin.sendMessage(inGame, ChatFormatting.parseLegacyMini(event.getMessage().apply(inGame)
                                 .replace("%bw_team_name%", team.getDisplayName(lang))
                                 .replace("%bw_player_color%", team.getColor().chat().toString()).replace("%bw_player%", p.getDisplayName()).replace("%bw_playername%", p.getName())
                                 .replace("%bw_killer_color%", killerTeam.getColor().chat().toString())
@@ -949,7 +948,7 @@ public class Arena implements IArena {
                     }
                     for (Player inGame : getSpectators()) {
                         Language lang = Language.getPlayerLanguage(inGame);
-                        BedWars.plugin.adventure().player(inGame).sendMessage(ChatFormatting.parseLegacyMini(event.getMessage().apply(inGame)
+                        BedWars.plugin.sendMessage(inGame, ChatFormatting.parseLegacyMini(event.getMessage().apply(inGame)
                                 .replace("%bw_team_name%", team.getDisplayName(lang))
                                 .replace("%bw_player_color%", team.getColor().chat().toString()).replace("%bw_player%", p.getDisplayName()).replace("%bw_playername%", p.getName())
                                 .replace("%bw_killer_color%", killerTeam.getColor().chat().toString())
@@ -962,7 +961,7 @@ public class Arena implements IArena {
         }
         for (Player on : getPlayers()) {
             Language language = Language.getPlayerLanguage(on);
-            BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_LEAVE_MSG)
+            BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_LEAVE_MSG)
                     .replace("%bw_v_prefix%", getChatSupport().getPrefix(p))
                     .replace("%bw_v_suffix%", getChatSupport().getSuffix(p))
                     .replace("%bw_playername%", p.getName())
@@ -973,7 +972,7 @@ public class Arena implements IArena {
         }
         for (Player on : getSpectators()) {
             Language language = Language.getPlayerLanguage(on);
-            BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_LEAVE_MSG)
+            BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(language, p, Messages.COMMAND_LEAVE_MSG)
                     .replace("%bw_v_prefix%", getChatSupport().getPrefix(p))
                     .replace("%bw_v_suffix%", getChatSupport().getSuffix(p))
                     .replace("%bw_playername%", p.getName())
@@ -1056,7 +1055,7 @@ public class Arena implements IArena {
                         if (status == GameState.starting && (maxInTeam > players.size() && teamuri || players.size() < minPlayers && !teamuri)) {
                             changeStatus(GameState.waiting);
                             for (Player on : players) {
-                                BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(on, Messages.ARENA_START_COUNTDOWN_STOPPED_INSUFF_PLAYERS_CHAT)));
+                                BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(on, Messages.ARENA_START_COUNTDOWN_STOPPED_INSUFF_PLAYERS_CHAT)));
                             }
                         }
                     }
@@ -1248,10 +1247,10 @@ public class Arena implements IArena {
         leaving.remove(p);
 
         for (Player on : players) {
-            BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("%bw_playername%", p.getName()).replace("%bw_player%", p.getDisplayName()).replace("%bw_on%", String.valueOf(getPlayers().size())).replace("%bw_max%", String.valueOf(getMaxPlayers()))));
+            BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("%bw_playername%", p.getName()).replace("%bw_player%", p.getDisplayName()).replace("%bw_on%", String.valueOf(getPlayers().size())).replace("%bw_max%", String.valueOf(getMaxPlayers()))));
         }
         for (Player on : spectators) {
-            BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("%bw_playername%", p.getName()).replace("%bw_player%", p.getDisplayName()).replace("%bw_on%", String.valueOf(getPlayers().size())).replace("%bw_max%", String.valueOf(getMaxPlayers()))));
+            BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("%bw_playername%", p.getName()).replace("%bw_player%", p.getDisplayName()).replace("%bw_on%", String.valueOf(getPlayers().size())).replace("%bw_max%", String.valueOf(getMaxPlayers()))));
         }
         setArenaByPlayer(p, this);
         /* save player inventory etc */
@@ -2117,7 +2116,7 @@ public class Arena implements IArena {
                         }
                     }
                     for (Player p : world.getPlayers()) {
-                        BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_TEAM_WON_CHAT)
+                        BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_TEAM_WON_CHAT)
                                 .replace("%bw_team_color%", winner.getColor().chat().toString())
                                 .replace("%bw_team_name%", winner.getDisplayName(Language.getPlayerLanguage(p)))));
 
@@ -2147,7 +2146,7 @@ public class Arena implements IArena {
 
                                     .replace("%bw_winner_format%", getMaxInTeam() > 1 ? getMsg(p, Messages.FORMATTING_TEAM_WINNER_FORMAT).replace("%bw_winner_members%", winners.toString()) : getMsg(p, Messages.FORMATTING_SOLO_WINNER_FORMAT).replace("%bw_winner_members%", winners.toString()))
                                     .replace("%bw_team_color%", winner.getColor().chat().toString()).replace("%bw_team_name%", winner.getDisplayName(Language.getPlayerLanguage(p)));
-                            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(SupportPAPI.getSupportPAPI().replace(p, message)));
+                            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(SupportPAPI.getSupportPAPI().replace(p, message)));
                         }
                     }
                 }
@@ -2284,11 +2283,11 @@ public class Arena implements IArena {
             setNextEvent(NextEvent.GAME_END);
             if(!getPlayers().isEmpty())
                 for (Player p : getPlayers()) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_NO_WINNERS)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_NO_WINNERS)));
                 }
             if(!getSpectators().isEmpty())
                 for (Player p : getSpectators()) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_NO_WINNERS)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GAME_END_NO_WINNERS)));
             }
         }
 
@@ -2552,11 +2551,11 @@ public class Arena implements IArena {
      */
     public void sendDiamondsUpgradeMessages() {
         for (Player p : getPlayers()) {
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
                     getMsg(p, Messages.GENERATOR_HOLOGRAM_TYPE_DIAMOND)).replace("%bw_tier%", getMsg(p, (diamondTier == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)))));
         }
         for (Player p : getSpectators()) {
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
                     getMsg(p, Messages.GENERATOR_HOLOGRAM_TYPE_DIAMOND)).replace("%bw_tier%", getMsg(p, (diamondTier == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)))));
         }
     }
@@ -2567,11 +2566,11 @@ public class Arena implements IArena {
      */
     public void sendEmeraldsUpgradeMessages() {
         for (Player p : getPlayers()) {
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
                     getMsg(p, Messages.GENERATOR_HOLOGRAM_TYPE_EMERALD)).replace("%bw_tier%", getMsg(p, (emeraldTier == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)))));
         }
         for (Player p : getSpectators()) {
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.GENERATOR_UPGRADE_CHAT_ANNOUNCEMENT).replace("%bw_generator_type%",
                     getMsg(p, Messages.GENERATOR_HOLOGRAM_TYPE_EMERALD)).replace("%bw_tier%", getMsg(p, (emeraldTier == 2 ? Messages.FORMATTING_GENERATOR_TIER2 : Messages.FORMATTING_GENERATOR_TIER3)))));
         }
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/ReJoin.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/ReJoin.java
@@ -171,11 +171,11 @@ public class ReJoin {
             bwt.setBedDestroyed(true);
             if (bwt != null) {
                 for (Player p2 : arena.getPlayers()) {
-                    BedWars.plugin.adventure().player(p2).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", bwt.getColor().chat().toString())
+                    BedWars.plugin.sendMessage(p2,ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", bwt.getColor().chat().toString())
                             .replace("%bw_team_name%", bwt.getDisplayName(Language.getPlayerLanguage(p2)))));
                 }
                 for (Player p2 : arena.getSpectators()) {
-                    BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", bwt.getColor().chat().toString())
+                    BedWars.plugin.sendMessage(p2,ChatFormatting.parseLegacyMini(getMsg(p2, Messages.TEAM_ELIMINATED_CHAT).replace("%bw_team_color%", bwt.getColor().chat().toString())
                             .replace("%bw_team_name%", bwt.getDisplayName(Language.getPlayerLanguage(p2)))));
                 }
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/feature/GGFeature.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/feature/GGFeature.java
@@ -74,8 +74,8 @@ public class GGFeature implements Listener {
                         .replace("%bw_player%", winner.getName())
                         .replace("%bw_level%", BedWars.getAPI().getLevelsUtil().getLevel(winner))
                         .replace("%bw_team_color%", team.getColor().chat() + "[" + team.getDisplayName(Language.getPlayerLanguage(winner)).toUpperCase() + "]"));
-                BedWars.plugin.adventure().player(player).sendMessage(message);
-                BedWars.plugin.adventure().player(winner).sendMessage(message);
+                BedWars.plugin.sendMessage(player, message);
+                BedWars.plugin.sendMessage(winner, message);
                 winners.remove(player.getUniqueId());
                 winners.remove(winner.getUniqueId());
             }
@@ -92,8 +92,8 @@ public class GGFeature implements Listener {
                         .replace("%bw_player%", winner.getName())
                         .replace("%bw_level%", BedWars.getAPI().getLevelsUtil().getLevel(winner))
                         .replace("%bw_team_color%", team.getColor().chat() + "[" + team.getDisplayName(Language.getPlayerLanguage(winner)).toUpperCase() + "]"));
-                BedWars.plugin.adventure().player(player).sendMessage(message);
-                BedWars.plugin.adventure().player(winner).sendMessage(message);
+                BedWars.plugin.sendMessage(player, message);
+                BedWars.plugin.sendMessage(winner, message);
                 winners.remove(player.getUniqueId());
                 winners.remove(winner.getUniqueId());
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/feature/ResourceChestFeature.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/feature/ResourceChestFeature.java
@@ -129,7 +129,7 @@ public class ResourceChestFeature implements Listener {
         int inserted = attempted - notInserted;
 
         if (inserted <= 0) {
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.INTERACT_FULL_CHEST)));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.INTERACT_FULL_CHEST)));
             return;
         }
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameAnnouncementTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameAnnouncementTask.java
@@ -83,7 +83,7 @@ public class GameAnnouncementTask implements Runnable, AnnouncementTask {
         for (Player player : arena.getPlayers()) {
             if (arena.getStatus() == GameState.playing) {
                 try {
-                    BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(messages.get(player).get(index % messages.get(player).size())));
+                    BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(messages.get(player).get(index % messages.get(player).size())));
                 } catch (NullPointerException e){
                     // Player might lose data when rejoining after getting disconnected
                     loadMessagesForPlayer(player, Messages.ARENA_IN_GAME_ANNOUNCEMENT);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GamePlayingTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GamePlayingTask.java
@@ -114,11 +114,11 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                 if (getBedsDestroyCountdown() == 0) {
                     for (Player p : getArena().getPlayers()) {
                         BedWars.nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 40, 10);
-                        BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED)));
+                        BedWars.plugin.sendMessage(p,ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED)));
                     }
                     for (Player p : getArena().getSpectators()) {
                         BedWars.nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 40, 10);
-                        BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED)));
+                        BedWars.plugin.sendMessage(p,ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED)));
                     }
                     for (ITeam t : getArena().getTeams()) {
                         t.setBedDestroyed(true);
@@ -133,16 +133,14 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                         BedWars.nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 40, 10);
                         for (ITeam t : getArena().getTeams()) {
                             if (t.getMembers().isEmpty()) continue;
-                            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("%bw_dragons_amount%", String.valueOf(t.getDragonAmount()))
-                                    .replace("%bw_team_color%", t.getColor().chat().toString()).replace("%bw_team_name%", t.getDisplayName(Language.getPlayerLanguage(p)))));
+                            BedWars.plugin.sendMessage(p,ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("%bw_dragons_amount%", String.valueOf(t.getDragonAmount())).replace("%bw_team_color%", t.getColor().chat().toString()).replace("%bw_team_name%", t.getDisplayName(Language.getPlayerLanguage(p)))));
                         }
                     }
                     for (Player p : getArena().getSpectators()) {
                         BedWars.nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 40, 10);
                         for (ITeam t : getArena().getTeams()) {
                             if (t.getMembers().isEmpty()) continue;
-                            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("%bw_dragons_amount%", String.valueOf(t.getDragonAmount()))
-                                    .replace("%bw_team_color%", t.getColor().chat().toString()).replace("%bw_team_name%", t.getDisplayName(Language.getPlayerLanguage(p)))));
+                            BedWars.plugin.sendMessage(p,ChatFormatting.parseLegacyMini(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("%bw_dragons_amount%", String.valueOf(t.getDragonAmount())).replace("%bw_team_color%", t.getColor().chat().toString()).replace("%bw_team_name%", t.getDisplayName(Language.getPlayerLanguage(p)))));
                         }
                     }
                     getArena().updateNextEvent();
@@ -226,7 +224,7 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                     BedWars.nms.sendTitle(e.getKey(), getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_TITLE).replace("%bw_time%",
                             String.valueOf(e.getValue())), getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_SUBTITLE).replace("%bw_time%",
                             String.valueOf(e.getValue())), 0, 30, 10);
-                    BedWars.plugin.adventure().player(e.getKey()).sendMessage(ChatFormatting.parseLegacyMini(getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_CHAT).replace("%bw_time%", String.valueOf(e.getValue()))));
+                    BedWars.plugin.sendMessage(e.getKey(), ChatFormatting.parseLegacyMini(getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_CHAT).replace("%bw_time%", String.valueOf(e.getValue()))));
                     getArena().getRespawnSessions().replace(e.getKey(), e.getValue() - 1);
                 }
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameStartingTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/GameStartingTask.java
@@ -161,7 +161,7 @@ public class GameStartingTask implements Runnable, StartingTask {
                 Language playerLang = Language.getPlayerLanguage(player);
                 String[] titleSubtitle = Language.getCountDownTitle(playerLang, getCountdown());
                 BedWars.nms.sendTitle(player, titleSubtitle[0], titleSubtitle[1], 0, 20, 10);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.ARENA_STATUS_START_COUNTDOWN_CHAT).replace("%bw_time%", String.valueOf(getCountdown()))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.ARENA_STATUS_START_COUNTDOWN_CHAT).replace("%bw_time%", String.valueOf(getCountdown()))));
             }
         }
         countdown--;
@@ -191,7 +191,7 @@ public class GameStartingTask implements Runnable, StartingTask {
                 Sounds.playSound(ConfigPath.SOUND_GAME_START, p);
                 BedWars.nms.sendTitle(p, getMsg(p, Messages.ARENA_STATUS_START_PLAYER_TITLE), null, 0, 30, 10);
                 for (String tut : getList(p, Messages.ARENA_STATUS_START_PLAYER_TUTORIAL)) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(SupportPAPI.getSupportPAPI().replace(p, tut)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(SupportPAPI.getSupportPAPI().replace(p, tut)));
                 }
             }
         }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/tasks/HologramTask.java
@@ -40,10 +40,15 @@ public class HologramTask implements Runnable {
                     for (ShopHolo shopHolo : shopHolos) {
                         if (shopHolo == null) continue;
                         IHologram hologram = shopHolo.getHologram();
-                        Location holoLoc = hologram.getLocation();
-                        double distance = pLoc.distance(holoLoc);
-                        if (distance <= BedWars.hologramUpdateDistance) continue;
-                        shopHolo.update(p);
+                    if (hologram == null) continue;
+
+                    Location holoLoc = hologram.getLocation();
+                    if (holoLoc == null || holoLoc.getWorld() != pLoc.getWorld()) continue;
+
+                    double distance = pLoc.distance(holoLoc);
+                    if (distance > BedWars.hologramUpdateDistance) continue;
+
+                    shopHolo.update(p);
                     }
                 }
 
@@ -52,16 +57,24 @@ public class HologramTask implements Runnable {
                         if (p == null || !p.isOnline()) continue;
                         if (p.getWorld() != world) continue;
                         String iso = Language.getPlayerLanguage(p).getIso();
-                        IBedHolo bedHolo = team.getBedHologram(iso);
-                        if (bedHolo == null) continue;
-                        Location bedLoc = bedHolo.getHologram().getLocation();
-                        Location pLoc = p.getLocation();
-                        double distance = pLoc.distance(bedLoc);
+                    IBedHolo bedHolo = team.getBedHologram(iso);
+                    if (bedHolo == null || bedHolo.getHologram() == null) continue;
 
-                        if (distance <= 4) bedHolo.hide(p);
-                        else if (distance > 4 && distance <= 8) bedHolo.show(p);
+                    Location bedLoc = bedHolo.getHologram().getLocation();
+                    Location pLoc = p.getLocation();
+                    if (bedLoc == null || bedLoc.getWorld() != pLoc.getWorld()) continue;
 
-                        if (distance >= BedWars.hologramUpdateDistance) bedHolo.update(p);
+                    double distance = pLoc.distance(bedLoc);
+
+                    if (distance <= 4) {
+                        bedHolo.hide(p);
+                    } else if (distance <= 8) {
+                        bedHolo.show(p);
+                    }
+
+                    if (distance <= BedWars.hologramUpdateDistance) {
+                        bedHolo.update(p);
+                    }
                     }
                 }
 
@@ -72,21 +85,28 @@ public class HologramTask implements Runnable {
                     Location genLoc = generator.getLocation();
                     for (Player p : world.getPlayers()) {
                         if (p == null || !p.isOnline()) continue;
-                        String iso = Language.getPlayerLanguage(p).getIso();
-                        IGenHolo holo = generator.getLanguageHolograms().get(iso);
-                        if (holo == null) continue;
-                        GeneratorHolder holder = generator.getHologramHolder();
-                        Location pLoc = p.getLocation();
-                        double distance = pLoc.distance(genLoc);
-                        if (distance <= BedWars.hologramUpdateDistance) continue;
+
+                    Location pLoc = p.getLocation();
+                    if (pLoc.getWorld() != genLoc.getWorld()) continue;
+
+                    double distance = pLoc.distance(genLoc);
+                    if (distance > BedWars.hologramUpdateDistance) continue;
+
+                    String iso = Language.getPlayerLanguage(p).getIso();
+                    IGenHolo holo = generator.getLanguageHolograms().get(iso);
+                    if (holo != null) {
                         holo.update(p);
-                        if (holder == null) continue;
+                    }
+
+                    GeneratorHolder holder = generator.getHologramHolder();
+                    if (holder != null) {
                         holder.update(p);
                     }
                 }
             }
-        } catch (Exception e) {
-            BedWars.debug("An error occurred while updating holograms: " + e.getMessage());
         }
+    } catch (Exception e) {
+        BedWars.debug("An error occurred while updating holograms: " + e.getMessage());
+    }
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/team/BedWarsTeam.java
@@ -413,7 +413,7 @@ public class BedWarsTeam implements ITeam {
         }, 8L);
 
         nms.sendTitle(p, getMsg(p, Messages.PLAYER_DIE_RESPAWNED_TITLE), "", 0, 20, 10);
-        BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.PLAYER_DIE_RESPAWNED_TEXT)));
+        BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.PLAYER_DIE_RESPAWNED_TEXT)));
 
         sendDefaultInventory(p, false);
         ShopCache sc = ShopCache.getInstance().getShopCache(p.getUniqueId());

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/commands/bedwars/MainCommand.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/commands/bedwars/MainCommand.java
@@ -135,15 +135,15 @@ public class MainCommand extends BukkitCommand implements ParentCommand {
                     if (SetupSession.isInSetupSession(((Player) s).getUniqueId())) {
                         Bukkit.dispatchCommand(s, getName() + " cmds");
                     } else {
-                        BedWars.plugin.adventure().sender(s).sendMessage(Component.text(" "));
-                        BedWars.plugin.adventure().sender(s).sendMessage(ChatFormatting.parseLegacyMini("§8§l" + dot + " §6" + plugin.getDescription().getName() + " v" + plugin.getDescription().getVersion() + " §7- §c Admin Commands"));
-                        BedWars.plugin.adventure().sender(s).sendMessage(Component.text(" "));
+                        BedWars.plugin.sendMessage(s, Component.text(" "));
+                        BedWars.plugin.sendMessage(s, ChatFormatting.parseLegacyMini("§8§l" + dot + " §6" + plugin.getDescription().getName() + " v" + plugin.getDescription().getVersion() + " §7- §c Admin Commands"));
+                        BedWars.plugin.sendMessage(s, Component.text(" "));
                         sendSubCommands(s);
                     }
                 } else {
-                    BedWars.plugin.adventure().sender(s).sendMessage(Component.text(" "));
-                    BedWars.plugin.adventure().sender(s).sendMessage(ChatFormatting.parseLegacyMini("§8§l" + dot + " §6" + plugin.getDescription().getName() + " v" + plugin.getDescription().getVersion() + " §7- §c Console Commands"));
-                    BedWars.plugin.adventure().sender(s).sendMessage(Component.text(" "));
+                    BedWars.plugin.sendMessage(s, Component.text(" "));
+                    BedWars.plugin.sendMessage(s, ChatFormatting.parseLegacyMini("§8§l" + dot + " §6" + plugin.getDescription().getName() + " v" + plugin.getDescription().getVersion() + " §7- §c Console Commands"));
+                    BedWars.plugin.sendMessage(s, Component.text(" "));
                     sendSubCommands(s);
                 }
             } else {
@@ -164,11 +164,9 @@ public class MainCommand extends BukkitCommand implements ParentCommand {
 
         if (!commandFound) {
             if (s instanceof Player) {
-                BedWars.plugin.adventure().sender(s)
-                        .sendMessage(ChatFormatting.parseLegacyMini(getMsg((Player) s, Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
+                BedWars.plugin.sendMessage(s, ChatFormatting.parseLegacyMini(getMsg((Player) s, Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
             } else {
-                BedWars.plugin.adventure().sender(s)
-                        .sendMessage(ChatFormatting.parseLegacyMini(Language.getDefaultLanguage().m(Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
+                BedWars.plugin.sendMessage(s, ChatFormatting.parseLegacyMini(Language.getDefaultLanguage().m(Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
             }
         }
         return true;
@@ -207,7 +205,7 @@ public class MainCommand extends BukkitCommand implements ParentCommand {
             for (int i = 0; i <= 20; i++) {
                 for (SubCommand sb : getSubCommands()) {
                     if (sb.getPriority() == i && sb.isShow() && sb.canSee(p, BedWars.getAPI())) {
-                        BedWars.plugin.adventure().sender(p).sendMessage(ChatFormatting.parseLegacyMini(sb.getDisplayInfo().getText()));
+                        BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(sb.getDisplayInfo().getText()));
                     }
                 }
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/commands/bedwars/subcmds/regular/CmdJoin.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/commands/bedwars/subcmds/regular/CmdJoin.java
@@ -55,14 +55,14 @@ public class CmdJoin extends SubCommand {
         if (s instanceof ConsoleCommandSender) return false;
         Player p = (Player) s;
         if (args.length < 1) {
-            BedWars.plugin.adventure().sender(s)
-                    .sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_USAGE)));
+            BedWars.plugin
+                    .sendMessage(s, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_USAGE)));
             return true;
         }
         if (args[0].equalsIgnoreCase("random")){
             if (!Arena.joinRandomArena(p)){
-                BedWars.plugin.adventure().sender(s)
-                        .sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_NO_EMPTY_FOUND)));
+                BedWars.plugin
+                        .sendMessage(s, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_NO_EMPTY_FOUND)));
                 Sounds.playSound("join-denied", p);
             } else {
                 Sounds.playSound("join-allowed", p);
@@ -71,8 +71,8 @@ public class CmdJoin extends SubCommand {
         }
         if (MainCommand.isArenaGroup(args[0]) || args[0].contains("+")) {
             if (!Arena.joinRandomFromGroup(p, args[0])) {
-                BedWars.plugin.adventure().sender(s)
-                        .sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_NO_EMPTY_FOUND)));
+                BedWars.plugin
+                        .sendMessage(s, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_NO_EMPTY_FOUND)));
                 Sounds.playSound("join-denied", p);
             } else {
                 Sounds.playSound("join-allowed", p);
@@ -94,8 +94,8 @@ public class CmdJoin extends SubCommand {
             return true;
         }
 
-        BedWars.plugin.adventure().sender(s)
-                .sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_GROUP_OR_ARENA_NOT_FOUND).replace("%bw_name%", args[0])));
+        BedWars.plugin
+                .sendMessage(s, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_JOIN_GROUP_OR_ARENA_NOT_FOUND).replace("%bw_name%", args[0])));
         return true;
     }
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/halloween/HalloweenListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/halloween/HalloweenListener.java
@@ -99,7 +99,7 @@ public class HalloweenListener implements Listener {
             if (level != null) {
                 e.getBlock().getDrops().clear();
                 level.addXp(5, PlayerXpGainEvent.XpSource.OTHER);
-                BedWars.plugin.adventure().player(e.getPlayer()).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(e.getPlayer(), Messages.XP_REWARD_HALLOWEEN)));
+                BedWars.plugin.sendMessage(e.getPlayer() ,ChatFormatting.parseLegacyMini(Language.getMsg(e.getPlayer(), Messages.XP_REWARD_HALLOWEEN)));
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/levels/internal/LevelListeners.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/levels/internal/LevelListeners.java
@@ -77,7 +77,7 @@ public class LevelListeners implements Listener {
                 int xpAmount = LevelsConfig.levels.getInt("xp-rewards.game-win");
                 if (xpAmount > 0) {
                     PlayerLevel.getLevelByPlayer(p).addXp(xpAmount, PlayerXpGainEvent.XpSource.GAME_WIN);
-                    BedWars.plugin.adventure().player(p1).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.XP_REWARD_WIN).replace("%bw_xp%", String.valueOf(xpAmount))));
+                    BedWars.plugin.sendMessage(p1, ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.XP_REWARD_WIN).replace("%bw_xp%", String.valueOf(xpAmount))));
                 }
                 ITeam bwt = e.getArena().getExTeam(p1.getUniqueId());
                 if (bwt != null) {
@@ -86,7 +86,7 @@ public class LevelListeners implements Listener {
                         if (xpAmountPerTmt > 0) {
                             int tr = xpAmountPerTmt * bwt.getMembersCache().size();
                             PlayerLevel.getLevelByPlayer(p).addXp(tr, PlayerXpGainEvent.XpSource.PER_TEAMMATE);
-                            BedWars.plugin.adventure().player(p1).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p1, "xp-reward-per-teammate").replace("%bw_xp%", String.valueOf(tr))));
+                            BedWars.plugin.sendMessage(p1, ChatFormatting.parseLegacyMini(Language.getMsg(p1, "xp-reward-per-teammate").replace("%bw_xp%", String.valueOf(tr))));
                         }
                     }
                 }
@@ -103,7 +103,7 @@ public class LevelListeners implements Listener {
                         if (xpAmountPerTmt > 0) {
                             int tr = LevelsConfig.levels.getInt("xp-rewards.per-teammate") * bwt.getMembersCache().size();
                             PlayerLevel.getLevelByPlayer(p).addXp(tr, PlayerXpGainEvent.XpSource.PER_TEAMMATE);
-                            BedWars.plugin.adventure().player(p1).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.XP_REWARD_PER_TEAMMATE).replace("%bw_xp%", String.valueOf(tr))));
+                            BedWars.plugin.sendMessage(p1, ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.XP_REWARD_PER_TEAMMATE).replace("%bw_xp%", String.valueOf(tr))));
                         }
                     }
                 }
@@ -129,7 +129,7 @@ public class LevelListeners implements Listener {
         int bedDestroy = LevelsConfig.levels.getInt("xp-rewards.bed-destroyed");
         if (bedDestroy > 0) {
             PlayerLevel.getLevelByPlayer(player.getUniqueId()).addXp(bedDestroy, PlayerXpGainEvent.XpSource.BED_DESTROYED);
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_BED_DESTROY).replace("%bw_xp%", String.valueOf(bedDestroy))));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_BED_DESTROY).replace("%bw_xp%", String.valueOf(bedDestroy))));
         }
     }
 
@@ -145,12 +145,12 @@ public class LevelListeners implements Listener {
         if (e.getCause().isFinalKill()) {
             if (finalKill > 0) {
                 PlayerLevel.getLevelByPlayer(player.getUniqueId()).addXp(finalKill, PlayerXpGainEvent.XpSource.FINAL_KILL);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_FINAL_KILL).replace("%bw_xp%", String.valueOf(finalKill))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_FINAL_KILL).replace("%bw_xp%", String.valueOf(finalKill))));
             }
         } else {
             if (regularKill > 0) {
                 PlayerLevel.getLevelByPlayer(player.getUniqueId()).addXp(regularKill, PlayerXpGainEvent.XpSource.REGULAR_KILL);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_REGULAR_KILL).replace("%bw_xp%", String.valueOf(regularKill))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.XP_REWARD_REGULAR_KILL).replace("%bw_xp%", String.valueOf(regularKill))));
             }
         }
     }
@@ -165,7 +165,7 @@ public class LevelListeners implements Listener {
 
         List<String> messages = Language.getList(player, Messages.PLAYER_LEVEL_UP);
         for (String message : messages) {
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(message.replace("%bw_level%", newLevel)));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(message.replace("%bw_level%", newLevel)));
         }
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/levels/internal/PerMinuteTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/levels/internal/PerMinuteTask.java
@@ -48,7 +48,7 @@ public class PerMinuteTask {
             for (Player p : arena.getPlayers()) {
                 PlayerLevel.getLevelByPlayer ( p.getUniqueId () ).addXp ( xp, PlayerXpGainEvent.XpSource.PER_MINUTE );
                 String msg = Language.getMsg ( p, Messages.XP_REWARD_PER_MINUTE ).replace ( "%bw_xp%", String.valueOf ( xp ) );
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(msg));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(msg));
             }
         }, 60 * 20, 60 * 20);
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/BreakPlace.java
@@ -147,19 +147,19 @@ public class BreakPlace implements Listener {
             }
             if (e.getBlockPlaced().getLocation().getBlockY() >= a.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y)) {
                 e.setCancelled(true);
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(e.getPlayer(), Messages.ARENA_MAX_BUILD_LIMIT_REACHED)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(e.getPlayer(), Messages.ARENA_MAX_BUILD_LIMIT_REACHED)));
                 return;
             }
             if (e.getBlockPlaced().getLocation().getBlockY() <= a.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y)) {
                 e.setCancelled(true);
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(e.getPlayer(), Messages.ARENA_MIN_BUILD_LIMIT_REACHED)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(e.getPlayer(), Messages.ARENA_MIN_BUILD_LIMIT_REACHED)));
                 return;
             }
 
             for (Region r : a.getRegionsList()) {
                 if (r.isInRegion(e.getBlock().getLocation()) && r.isProtected()) {
                     e.setCancelled(true);
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK)));
                     return;
                 }
             }
@@ -345,7 +345,7 @@ public class BreakPlace implements Listener {
                                 if (t.getBed().getBlockX() == x && t.getBed().getBlockY() == y && t.getBed().getBlockZ() == z) {
                                     if (!t.isBedDestroyed()) {
                                         if (t.isMember(p)) {
-                                            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_OWN_BED)));
+                                            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_OWN_BED)));
                                             e.setCancelled(true);
                                             if (e.getPlayer().getLocation().getBlock().getType().toString().contains("BED")) {
                                                 PaperSupport.teleport(e.getPlayer(), e.getPlayer().getLocation().add(0, 0.5, 0));
@@ -384,7 +384,7 @@ public class BreakPlace implements Listener {
                                                             .replace("%bw_player_color%", a.getTeam(p).getColor().chat().toString())
                                                             .replace("%bw_player%", p.getDisplayName())
                                                             .replace("%bw_playername%", p.getName());
-                                                    BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(msg));
+                                                    BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(msg));
                                                 }
                                                 if (breakEvent.getTitle() != null && breakEvent.getSubTitle() != null) {
                                                     nms.sendTitle(on, breakEvent.getTitle().apply(on), breakEvent.getSubTitle().apply(on), 0, 40, 10);
@@ -406,14 +406,14 @@ public class BreakPlace implements Listener {
             for (Region r : a.getRegionsList()) {
                 if (r.isInRegion(e.getBlock().getLocation()) && r.isProtected()) {
                     e.setCancelled(true);
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_BLOCK)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_BLOCK)));
                     return;
                 }
             }
 
             if (!a.isMapBreakable()) {
                 if (!a.isBlockPlaced(e.getBlock())) {
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_BLOCK)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_BREAK_BLOCK)));
                     e.setCancelled(true);
                 }
             }
@@ -521,19 +521,19 @@ public class BreakPlace implements Listener {
                 return;
             }
             if (e.getBlockClicked().getRelative(e.getBlockFace()).getLocation().getBlockY() >= a.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MAX_BUILD_Y)) {
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.ARENA_MAX_BUILD_LIMIT_REACHED)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.ARENA_MAX_BUILD_LIMIT_REACHED)));
                 e.setCancelled(true);
                 return;
             }
             if (e.getBlockClicked().getRelative(e.getBlockFace()).getLocation().getBlockY() <= a.getConfig().getInt(ConfigPath.ARENA_CONFIGURATION_MIN_BUILD_Y)) {
                 e.setCancelled(true);
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.ARENA_MIN_BUILD_LIMIT_REACHED)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.ARENA_MIN_BUILD_LIMIT_REACHED)));
             }
 
             for (Region r : a.getRegionsList()) {
                 if (r.isInRegion(e.getBlockClicked().getRelative(e.getBlockFace()).getLocation()) && r.isProtected()) {
                     e.setCancelled(true);
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK)));
                     return;
                 }
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/CmdProcess.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/CmdProcess.java
@@ -41,12 +41,12 @@ public class CmdProcess implements Listener {
         Player p = e.getPlayer();
 
         if (e.getMessage().equals("/party sethome")){
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
             e.setCancelled(true);
         }
 
         if (e.getMessage().equals("/party home")){
-            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
+            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
             e.setCancelled(true);
         }
 
@@ -55,7 +55,7 @@ public class CmdProcess implements Listener {
         if (cmd.length == 0) return;
         if (Arena.isInArena(p)) {
             if (!BedWars.config.getList(ConfigPath.GENERAL_CONFIGURATION_ALLOWED_COMMANDS).contains(cmd[0])) {
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.COMMAND_NOT_ALLOWED_IN_GAME)));
                 e.setCancelled(true);
             }
         }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/DamageDeathMove.java
@@ -228,7 +228,7 @@ public class DamageDeathMove implements Listener {
                 .replace("%bw_player%", player.getDisplayName())
                 .replace("%bw_team%", team.getColor().chat() + team.getDisplayName(lang))
                 .replace("%bw_health_remaining%", new DecimalFormat("#.#").format(Math.max(((Player) e.getEntity()).getHealth() - e.getFinalDamage(), 0)));
-        BedWars.plugin.adventure().player(damager).sendMessage(ChatFormatting.parseLegacyMini(message));
+        BedWars.plugin.sendMessage(damager, ChatFormatting.parseLegacyMini(message));
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -352,7 +352,7 @@ public class DamageDeathMove implements Listener {
                                 a.getShowTime().remove(p);
                                 p.removePotionEffect(PotionEffectType.INVISIBILITY);
                                 ITeam team = a.getTeam(p);
-                                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN)));
+                                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN)));
                                 Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.REMOVED, team, p, a));
                             });
                         }
@@ -390,7 +390,7 @@ public class DamageDeathMove implements Listener {
                             a.getShowTime().remove(p);
                             p.removePotionEffect(PotionEffectType.INVISIBILITY);
                             ITeam team = a.getTeam(p);
-                            BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN)));
+                            BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_INVISIBILITY_REMOVED_DAMGE_TAKEN)));
                             Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.REMOVED, team, p, a));
                         });
                     }
@@ -591,7 +591,7 @@ public class DamageDeathMove implements Listener {
                     .replace("%bw_killer_playername%", killer == null ? "" : killer.getName())
                     .replace("%bw_killer_name%", killer == null ? "" : killer.getDisplayName())
                     .replace("%bw_killer_team_name%", killersTeam == null ? "" : killersTeam.getDisplayName(lang));
-            BedWars.plugin.adventure().player(on).sendMessage(ChatFormatting.parseLegacyMini(msg));
+            BedWars.plugin.sendMessage(on, ChatFormatting.parseLegacyMini(msg));
         }
 
         // increase stats to killer
@@ -624,14 +624,14 @@ public class DamageDeathMove implements Listener {
         if (victimsTeamBedDestroyed) {
             arena.addSpectator(victim, true, null);
             victimsTeam.getMembers().remove(victim);
-            BedWars.plugin.adventure().player(victim).sendMessage(ChatFormatting.parseLegacyMini(getMsg(victim, Messages.PLAYER_DIE_ELIMINATED_CHAT)));
+            BedWars.plugin.sendMessage(victim, ChatFormatting.parseLegacyMini(getMsg(victim, Messages.PLAYER_DIE_ELIMINATED_CHAT)));
             if (victimsTeam.getMembers().isEmpty()) {
                 Bukkit.getPluginManager().callEvent(new TeamEliminatedEvent(arena, victimsTeam));
                 for (Player p : arena.getWorld().getPlayers()) {
                     String msg = getMsg(p, Messages.TEAM_ELIMINATED_CHAT).replace(
                             "%bw_team_color%", victimsTeam.getColor().chat().toString()).replace("%bw_team_name%",
                             victimsTeam.getDisplayName(Language.getPlayerLanguage(p)));
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(msg));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(msg));
                 }
                 Bukkit.getScheduler().runTask(plugin, arena::checkWinner); // Does not really need to be async but since intensive better safe than sorry
             }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/EggBridge.java
@@ -110,7 +110,7 @@ public class EggBridge implements Listener {
 
             if ((isCloseToMaxBuildLimit && isLookingUp) || (isCloseToMinBuildLimit && isLookingDown) || isUnderBuildLimit || isAboveLimit) {
                 if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_WARN_PLAYER)) {
-                    BedWars.plugin.adventure().player(shooter).sendMessage(ChatFormatting.parseLegacyMini(getMsg(shooter, Messages.EGGBRIDGE_BUILD_LIMIT_WARNING)));
+                    BedWars.plugin.sendMessage(shooter, ChatFormatting.parseLegacyMini(getMsg(shooter, Messages.EGGBRIDGE_BUILD_LIMIT_WARNING)));
                 }
                 if (config.getBoolean(ConfigPath.GENERAL_EGGBRIDGE_BUILD_LIMIT_CANCEL_USAGE)) {
                     if (shooter.getGameMode() != GameMode.CREATIVE) {

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/FireballListener.java
@@ -99,7 +99,7 @@ public class FireballListener implements Listener {
             if (fireballCooldown >= 1.0) {
                 String msg = Language.getMsg(player, Messages.ARENA_FIREBALL_COOLDOWN)
                         .replace("%bw_cooldown%", String.valueOf((cooldown - timeDifference)/1000));
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(msg));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(msg));
             }
             return;
         }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/HungerWeatherSpawn.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/HungerWeatherSpawn.java
@@ -137,7 +137,7 @@ public class HungerWeatherSpawn implements Listener {
 
                 int task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     Arena.magicMilk.remove(p.getUniqueId());
-                    BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_MAGIC_MILK_REMOVED)));
+                    BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_MAGIC_MILK_REMOVED)));
                     debug("PlayerItemConsumeEvent player " + p + " was removed from magicMilk");
                 }, 20L * Arena.getArenaByPlayer(p).getMagicMilkTime()).getTaskId();
 

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/Interact.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/Interact.java
@@ -176,7 +176,7 @@ public class Interact implements Listener {
                         if (!owner.isMember(p)) {
                             if (!(owner.getMembers().isEmpty() && owner.isBedDestroyed())) {
                                 e.setCancelled(true);
-                                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED)));
+                                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(getMsg(p, Messages.INTERACT_CHEST_CANT_OPEN_TEAM_ELIMINATED)));
                             }
                         }
                     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/chat/ChatFormatting.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/listeners/chat/ChatFormatting.java
@@ -113,12 +113,12 @@ public class ChatFormatting implements Listener {
             if (isShouting(msg, language)) {
                 if (!(p.hasPermission(Permissions.PERMISSION_SHOUT_COMMAND) || p.hasPermission(Permissions.PERMISSION_ALL))) {
                     e.setCancelled(true);
-                    BedWars.plugin.adventure().player(p).sendMessage(parseLegacyMini(Language.getMsg(p, Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
+                    BedWars.plugin.sendMessage(p, parseLegacyMini(Language.getMsg(p, Messages.COMMAND_NOT_FOUND_OR_INSUFF_PERMS)));
                     return;
                 }
                 if (ShoutCommand.isShoutCooldown(p)) {
                     e.setCancelled(true);
-                    BedWars.plugin.adventure().player(p).sendMessage(parseLegacyMini(language.m(Messages.COMMAND_COOLDOWN)
+                    BedWars.plugin.sendMessage(p, parseLegacyMini(language.m(Messages.COMMAND_COOLDOWN)
                             .replace("%bw_seconds%", String.valueOf(Math.round(ShoutCommand.getShoutCooldown(p))))
                     ));
                     return;
@@ -200,9 +200,20 @@ public class ChatFormatting implements Listener {
     }
 
     public static Component parseLegacyMini(String s) {
-        s = s.replaceAll("§", "&");
+        if (s == null || s.isEmpty()) {
+            return Component.empty();
+        }
+
+        s = s.replace("§", "&");
+
+        if (BedWars.getServerVersion().equals("v1_16_R3")) {
+            return LegacyComponentSerializer.legacyAmpersand().deserialize(s);
+        }
+
         Component deserializedLegacy = LegacyComponentSerializer.legacyAmpersand().deserialize(s);
-        String miniSerializedLegacy = MiniMessage.miniMessage().serialize(deserializedLegacy).replace("\\<", "<");
+        String miniSerializedLegacy = MiniMessage.miniMessage()
+                .serialize(deserializedLegacy)
+                .replace("\\<", "<");
 
         return MiniMessage.miniMessage().deserialize(miniSerializedLegacy);
     }
@@ -210,15 +221,20 @@ public class ChatFormatting implements Listener {
     @SuppressWarnings("resource")
     public void sendMessage(AsyncPlayerChatEvent e, String format, String msg, Player eventTriggerPlayer, ITeam team){
         e.setCancelled(true);
-        BedWars.plugin.adventure().sender(Bukkit.getConsoleSender())
-                .sendMessage(parsePHolders(format, msg, eventTriggerPlayer,null, team)
-                        .replaceText(b -> b.match("%").replacement("%%"))); // Used for console message only.
+
+        Component consoleMessage = parsePHolders(format, msg, eventTriggerPlayer,null, team)
+                .replaceText(b -> b.match("%").replacement("%%")); // Used for console message only.
         // Create a copy to avoid ConcurrentModificationException
         List<Player> recipientsCopy = new ArrayList<>(recipients);
-        for (Player player : recipientsCopy) {
-            if (player == null) continue;
-            var adventurePlayer = BedWars.plugin.adventure().player(player);
-            adventurePlayer.sendMessage(parsePHolders(format, msg, eventTriggerPlayer, player, team));
-        }
+
+        // AsyncPlayerChatEvent can run async, so send messages safely on the main thread.
+        Bukkit.getScheduler().runTask(BedWars.plugin, () -> {
+            BedWars.plugin.sendMessage(Bukkit.getConsoleSender(), consoleMessage);
+            for (Player player : recipientsCopy){
+                if (player == null) continue;
+                Component playerMessage = parsePHolders(format, msg, eventTriggerPlayer, player, team);
+                BedWars.plugin.sendMessage(player, playerMessage);
+            }
+        });
     }
 }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/money/internal/MoneyListeners.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/money/internal/MoneyListeners.java
@@ -54,7 +54,7 @@ public class MoneyListeners implements Listener {
                 Bukkit.getPluginManager().callEvent(event);
                 if (event.isCancelled()) return;
                 BedWars.getEconomy().giveMoney(player, event.getAmount());
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_WIN).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_WIN).replace("%bw_money%", String.valueOf(event.getAmount()))));
             }
             ITeam bwt = e.getArena().getExTeam(player.getUniqueId());
             IArena arena = e.getArena();
@@ -66,7 +66,7 @@ public class MoneyListeners implements Listener {
                         Bukkit.getPluginManager().callEvent(event);
                         if (event.isCancelled()) return;
                         BedWars.getEconomy().giveMoney(player, event.getAmount());
-                        BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                        BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("%bw_money%", String.valueOf(event.getAmount()))));
                     }
                 }
             }
@@ -84,7 +84,7 @@ public class MoneyListeners implements Listener {
                         Bukkit.getPluginManager().callEvent(event);
                         if (event.isCancelled()) return;
                         BedWars.getEconomy().giveMoney(player, event.getAmount());
-                        BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                        BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("%bw_money%", String.valueOf(event.getAmount()))));
                     }
                 }
             }
@@ -104,7 +104,7 @@ public class MoneyListeners implements Listener {
             Bukkit.getPluginManager().callEvent(event);
             if (event.isCancelled()) return;
             BedWars.getEconomy().giveMoney(player, event.getAmount());
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_BED_DESTROYED).replace("%bw_money%", String.valueOf(event.getAmount()))));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_BED_DESTROYED).replace("%bw_money%", String.valueOf(event.getAmount()))));
         }
     }
 
@@ -124,7 +124,7 @@ public class MoneyListeners implements Listener {
                 Bukkit.getPluginManager().callEvent(event);
                 if (event.isCancelled()) return;
                 BedWars.getEconomy().giveMoney(player, event.getAmount());
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_FINAL_KILL).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_FINAL_KILL).replace("%bw_money%", String.valueOf(event.getAmount()))));
             }
         } else {
             if (regularKill > 0) {
@@ -132,7 +132,7 @@ public class MoneyListeners implements Listener {
                 Bukkit.getPluginManager().callEvent(event);
                 if (event.isCancelled()) return;
                 BedWars.getEconomy().giveMoney(player, event.getAmount());
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_REGULAR_KILL).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.MONEY_REWARD_REGULAR_KILL).replace("%bw_money%", String.valueOf(event.getAmount()))));
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/money/internal/MoneyPerMinuteTask.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/money/internal/MoneyPerMinuteTask.java
@@ -54,7 +54,7 @@ public class MoneyPerMinuteTask {
                 Bukkit.getPluginManager().callEvent(event);
                 if (event.isCancelled()) return;
                 BedWars.getEconomy().giveMoney(p, event.getAmount());
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.MONEY_REWARD_PER_MINUTE).replace("%bw_money%", String.valueOf(event.getAmount()))));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.MONEY_REWARD_PER_MINUTE).replace("%bw_money%", String.valueOf(event.getAmount()))));
             }
         }, 60 * 20, 60 * 20);
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/main/CategoryContent.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/shop/main/CategoryContent.java
@@ -162,7 +162,7 @@ public class CategoryContent implements ICategoryContent {
 
         //check weight
         if (shopCache.getCategoryWeight(father) > weight) {
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_ALREADY_HIGHER_TIER)));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_ALREADY_HIGHER_TIER)));
             Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
             return false;
         }
@@ -175,7 +175,7 @@ public class CategoryContent implements ICategoryContent {
         //check if can re-buy
         if (shopCache.getContentTier(getIdentifier()) == contentTiers.size()) {
             if (isPermanent() && shopCache.hasCachedItem(this)) {
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_ALREADY_BOUGHT)));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_ALREADY_BOUGHT)));
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
                 return false;
             }
@@ -189,7 +189,7 @@ public class CategoryContent implements ICategoryContent {
         // Check money
         int money = calculateMoney(player, ct.getCurrency());
         if (money < ct.getPrice()) {
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY).replace("%bw_currency%", getMsg(player, getCurrencyMsgPath(ct))).
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY).replace("%bw_currency%", getMsg(player, getCurrencyMsgPath(ct))).
                     replace("%bw_amount%", String.valueOf(ct.getPrice() - money))));
             Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
             return false;
@@ -203,7 +203,7 @@ public class CategoryContent implements ICategoryContent {
         // Check inventory has space
         if (player.getInventory().firstEmpty() == -1){
             Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
-            BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.UPGRADES_LORE_REPLACEMENT_INSUFFICIENT_SPACE)));
+            BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.UPGRADES_LORE_REPLACEMENT_INSUFFICIENT_SPACE)));
             return false;
         }
 
@@ -223,15 +223,15 @@ public class CategoryContent implements ICategoryContent {
         if (itemNamePath == null || Language.getPlayerLanguage(player).getYml().get(itemNamePath) == null) {
             ItemStack displayItem = ct.getItemStack();
             if (displayItem.getItemMeta() != null && displayItem.getItemMeta().hasDisplayName()) {
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", displayItem.getItemMeta().getDisplayName())));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", displayItem.getItemMeta().getDisplayName())));
             }
         } else {
             if (isUpgradable()) {
                 int tierI = ct.getValue();
                 String tier = getRomanNumber(tierI);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", ChatColor.stripColor(getMsg(player, itemNamePath))).replace("%bw_color%", "").replace("%bw_tier%", tier)));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", ChatColor.stripColor(getMsg(player, itemNamePath))).replace("%bw_color%", "").replace("%bw_tier%", tier)));
             } else {
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", ChatColor.stripColor(getMsg(player, itemNamePath))).replace("%bw_color%", "").replace("%bw_tier%", "")));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(getMsg(player, Messages.SHOP_NEW_PURCHASE).replace("%bw_item%", ChatColor.stripColor(getMsg(player, itemNamePath))).replace("%bw_color%", "").replace("%bw_tier%", "")));
             }
         }
         shopCache.setCategoryWeight(father, weight);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/vault/NoChat.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/vault/NoChat.java
@@ -40,7 +40,7 @@ public class NoChat implements IChat {
 
     @Override
     public void sendMessage(Player player, String msg) {
-        BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(msg));
+        BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(msg));
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/vault/WithChat.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/vault/WithChat.java
@@ -44,7 +44,7 @@ public class WithChat implements IChat {
 
     @Override
     public void sendMessage(Player player, String msg) {
-        BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(msg));
+        BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(msg));
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/menu/MenuBaseTrap.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/menu/MenuBaseTrap.java
@@ -234,7 +234,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
         if (queueLimit <= team.getActiveTraps().size()) {
             if (announceAlreadyUnlocked){
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.UPGRADES_TRAP_QUEUE_LIMIT)));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.UPGRADES_TRAP_QUEUE_LIMIT)));
             }
             return false;
         }
@@ -268,7 +268,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
             int money = BedWars.getUpgradeManager().getMoney(player, currency);
             if (money < cost) {
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY)
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY)
                         .replace("%bw_currency%", BedWars.getUpgradeManager().getCurrencyMsg(player, cost, currency))
                         .replace("%bw_amount%", String.valueOf(cost - money))));
                 player.closeInventory();
@@ -303,7 +303,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
 
         if (announcePurchase){
             for (Player p1 : team.getMembers()) {
-                BedWars.plugin.adventure().player(p1).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("%bw_playername%", player.getName()).replace("%bw_player%", player.getDisplayName()).replace("%bw_upgrade_name%",
+                BedWars.plugin.sendMessage(p1, ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("%bw_playername%", player.getName()).replace("%bw_player%", player.getDisplayName()).replace("%bw_upgrade_name%",
                         ChatColor.stripColor(Language.getMsg(p1, Messages.UPGRADES_BASE_TRAP_ITEM_NAME_PATH + getName().replace("base-trap-", "")).replace("%bw_color%", "")))));
             }
         }
@@ -359,7 +359,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
             for (Player p : trapTeam.getMembers()) {
                 String trapName = ChatColor.stripColor(Language.getMsg(p, getNameMsgPath())).replace("%bw_color%", "");
                 String enemy = trapTeam.getArena().getTeam(player) == null ? "NULL" : trapTeam.getArena().getTeam(player).getDisplayName(Language.getPlayerLanguage(p));
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.UPGRADES_TRAP_CUSTOM_MSG + name2).replace("%bw_trap%", trapName)
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.UPGRADES_TRAP_CUSTOM_MSG + name2).replace("%bw_trap%", trapName)
                         .replace("%bw_playername%", player.getName()).replace("%bw_player%", player.getDisplayName()).replace("%bw_team%", enemy).replace("%bw_color%", color)));
                 BedWars.nms.sendTitle(p, Language.getMsg(p, Messages.UPGRADES_TRAP_CUSTOM_TITLE + name2)
                                 .replace("%bw_trap%", trapName).replace("%bw_playername%", player.getName()).replace("%bw_team%", enemy).replace("%bw_color%", color),
@@ -369,7 +369,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
         } else {
             for (Player p : trapTeam.getMembers()) {
                 String trapName = ChatColor.stripColor(Language.getMsg(p, getNameMsgPath())).replace("%bw_color%", "");
-                BedWars.plugin.adventure().player(p).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.UPGRADES_TRAP_DEFAULT_MSG).replace("%bw_trap%", trapName)));
+                BedWars.plugin.sendMessage(p, ChatFormatting.parseLegacyMini(Language.getMsg(p, Messages.UPGRADES_TRAP_DEFAULT_MSG).replace("%bw_trap%", trapName)));
                 BedWars.nms.sendTitle(p, Language.getMsg(p, Messages.UPGRADES_TRAP_DEFAULT_TITLE)
                         .replace("%bw_trap%", trapName), Language.getMsg(p, Messages.UPGRADES_TRAP_DEFAULT_SUBTITLE)
                         .replace("%bw_trap%", trapName), 15, 35, 10);

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/menu/MenuUpgrade.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/upgrades/menu/MenuUpgrade.java
@@ -137,7 +137,7 @@ public class MenuUpgrade implements MenuContent, TeamUpgrade {
         if (highest) {
             if (announceAlreadyUnlocked){
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
-                BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.UPGRADES_UPGRADE_ALREADY_CHAT)));
+                BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.UPGRADES_UPGRADE_ALREADY_CHAT)));
             }
             return false;
         }
@@ -149,7 +149,7 @@ public class MenuUpgrade implements MenuContent, TeamUpgrade {
                 int money = BedWars.getUpgradeManager().getMoney(player, ut.getCurrency());
                 if (money < ut.getCost()) {
                     Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, player);
-                    BedWars.plugin.adventure().player(player).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY)
+                    BedWars.plugin.sendMessage(player, ChatFormatting.parseLegacyMini(Language.getMsg(player, Messages.SHOP_INSUFFICIENT_MONEY)
                             .replace("%bw_currency%", BedWars.getUpgradeManager().getCurrencyMsg(player, ut))
                             .replace("%bw_amount%", String.valueOf(ut.getCost() - money))));
                     player.closeInventory();
@@ -181,7 +181,7 @@ public class MenuUpgrade implements MenuContent, TeamUpgrade {
 
             if (announcePurchase){
                 for (Player p1 : team.getMembers()) {
-                    BedWars.plugin.adventure().player(p1).sendMessage(ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("%bw_player%", player.getName()).replace("%bw_playername%", player.getDisplayName()).replace("%bw_upgrade_name%",
+                    BedWars.plugin.sendMessage(p1, ChatFormatting.parseLegacyMini(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("%bw_player%", player.getName()).replace("%bw_playername%", player.getDisplayName()).replace("%bw_upgrade_name%",
                             ChatColor.stripColor(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_TIER_ITEM_NAME.replace("%bw_name%", getName()
                                     .replace("upgrade-", "")).replace("%bw_tier%", ut.getName())).replace("%bw_color%", "")))));
                 }

--- a/versionsupport_v1_16_r3/build.gradle
+++ b/versionsupport_v1_16_r3/build.gradle
@@ -3,6 +3,18 @@ dependencies {
     implementation project(':versionsupport_common')
     compileOnly 'org.spigotmc:spigot:1.16.5-R0.1-SNAPSHOT'
     compileOnly 'org.apache.commons:commons-lang3:3.14.0'
+    implementation "net.kyori:adventure-api:4.14.0"
+    implementation "net.kyori:adventure-platform-bukkit:4.3.1"
+    implementation "net.kyori:adventure-text-minimessage:4.14.0"
+}
+
+tasks.named('compileJava', JavaCompile) {
+    options.release = 16
+}
+
+tasks.shadowJar {
+    archiveClassifier.set("")
+    relocate "net.kyori", "com.tomkeuper.bedwars.libs.kyori"
 }
 
 repositories {


### PR DESCRIPTION
#461

Fixes Paper 1.16.5 compatibility by avoiding Adventure Platform/MiniMessage code paths that conflict with Paper’s bundled Kyori Adventure classes.

On 1.16.5, the plugin could crash with `NoSuchMethodError` for `FacetAudience.getOrDefault(...)` or `Component.compact()` due to mixed Adventure versions at runtime. The fix disables `BukkitAudiences` on 1.16 and uses legacy Bukkit message sending as a fallback. Legacy message parsing now uses `LegacyComponentSerializer` directly instead of converting through MiniMessage.

I tested it and all works as intended as far as my tests go.