### PR TITLE
Add iron and gold generator in Generators arena config

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/arena/Arena.java
@@ -375,9 +375,9 @@ public class Arena implements IArena {
             bwt.spawnGenerators();
         }
 
-        //Load diamond/ emerald generators
+        //Load diamond / emerald / iron / gold generators
         Location location;
-        for (String type : Arrays.asList("Diamond", "Emerald")) {
+        for (String type : Arrays.asList("Diamond", "Emerald", "Iron", "Gold")) {
             if (yml.get("generator." + type) != null) {
                 for (String s : yml.getStringList("generator." + type)) {
                     location = cm.convertStringToArenaLocation(s);


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Adding iron and gold generators for arena (not team generators). This change will useful for setup some minigames from Bedwars2023 like Ranked Bedwars, custom Bedwars games, ...

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
May be useless if only use for setup normal Bedwars games.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
I tested in a bedwars arena with config:
```
group: Ranked
display-name: Aquarium
use-map: ''
minPlayers: 1
maxInTeam: 4
allowSpectate: true
spawn-protection: 5
shop-protection: 1
upgrades-protection: 1
generator-protection: 1
generator-split-range: 2.0
island-radius: 17
worldBorder: 300
y-kill-height: -1
max-build-y: 180
min-build-y: 0
disable-generator-for-empty-teams: false
disable-npcs-for-empty-teams: false
vanilla-death-drops: false
use-bed-hologram: false
allow-map-break: false
allow-dragon-destroy-when-protected: true
magicMilkTime: 30
game-rules:
- doDaylightCycle:false
- announceAdvancements:false
- doInsomnia:false
- doImmediateRespawn:true
- doWeatherCycle:false
- doFireTick:false
waiting:
  Loc: 0.5,118.0,0.5,0,0
  Pos1: -13.90715330213372,114.1495487674916,20.15106342695593,207.60177612304688,7.944355010986328
  Pos2: 14.79301742623377,135.50502502348886,-14.74519355756763,43.85113525390625,56.944026947021484
Team:
  Red:
    Color: RED
    Spawn: 61.5,87.0,0.5,89.90,0
    Bed: 48.0,87.0,0.0,0.0,0.0
    Shop:
    - 60.0,87.0,5.5,180,0
    - -4.5,87.0,60.0,-90,0
    Upgrade:
    - 58.0,87.0,5.5,180,0
    - -4.5,87.0,58.0,-90,0
    Iron:
    - 64.5,86.5,0.5,94.10198974609375,90.0
    Gold:
    - 64.5,86.5,0.5,94.10198974609375,90.0
    Emerald:
    - 64.5,86.5,0.5,94.10198974609375,90.0
  Green:
    Color: GREEN
    Spawn: -60.5,87.0,0.5,270,0
    Bed: -49.0,87.0,0.0,0.0,0.0
    Iron:
    - -63.5,86.5,0.5,270.29095458984375,90.0
    Gold:
    - -63.5,86.5,0.5,270.29095458984375,90.0
    Emerald:
    - -63.5,86.5,0.5,270.29095458984375,90.0
    Shop:
    - -59.0,87.0,-4.5,360,0
    - 5.5,87.0,-59,90,0
    Upgrade:
    - -57.0,87.0,-4.5,360,0
    - 5.5,87.0,-57,90,0
generator:
  Iron:
  - 0.5,86.5,64.5,178.41026306152344,89.9998550415039
  - 0.5,86.5,-63.5,358.1939697265625,90.0
  Gold:
  - 0.5,86.5,64.5,178.41026306152344,89.9998550415039
  - 0.5,86.5,-63.5,358.1939697265625,90.0
  Diamond:
  - 41.5,82.0,39.5,119.89562225341797,87.2453384399414
  - 39.5,82.0,-40.5,129.16091918945312,76.64403533935547
  - -40.5,83.0,-38.5,-39.958763122558594,90.0
  - -38.5,82.0,41.5,182.75177001953125,83.8228759765625
  Emerald:
  - 8.5,95.0,11.5,260.883544921875,88.16354370117188
  - -9.5,95.0,-10.5,62.630985260009766,82.15325164794922
```
and the Iron and Gold generators in ```generator:``` work normally. Because I only add type for generators loader so other functions wont affect.