### PR TITLE
fix the int for Iterable players, in Sounds

### DIFF
--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/Sounds.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/configuration/Sounds.java
@@ -100,8 +100,8 @@ public class Sounds {
     public static void playSound(String path, Iterable<Player> players) {
         if(path.equalsIgnoreCase("none")) return;
         final Sound sound = getSound(path);
-        int volume = getSounds().getInt(path + ".volume");
-        int pitch = getSounds().getInt(path + ".pitch");
+        float volume = (float) getSounds().getDouble(path + ".volume");
+        float pitch = (float) getSounds().getDouble(path + ".pitch");
         if (sound != null) {
             players.forEach(p -> p.playSound(p.getLocation(), sound, volume, pitch));
         }


### PR DESCRIPTION
The playSound fonction for multiple player at once (used by countdowns at arena start) wasn't using a proper float/double from the config. In fact it was casting it to an int as described in the issue
Fixes #451 