### PR TITLE
Update depecrated API usage for citizens NPC skins

### DIFF
--- a/bedwars-plugin/build.gradle
+++ b/bedwars-plugin/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     }
     compileOnly 'de.simonsator:DevelopmentPAFSpigot:1.0.67'
     compileOnly 'com.alessiodp.parties:parties-api:3.2.9'
-    compileOnly('net.citizensnpcs:citizens-main:2.0.30-SNAPSHOT') {
+    compileOnly('net.citizensnpcs:citizens-main:2.0.35-SNAPSHOT') {
         exclude group: 'junit', module: 'junit'
         exclude group: 'org.bstats', module: 'bstats-bukkit'
     }

--- a/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/citizens/JoinNPC.java
+++ b/bedwars-plugin/src/main/java/com/tomkeuper/bedwars/support/citizens/JoinNPC.java
@@ -28,6 +28,7 @@ import com.tomkeuper.bedwars.arena.Misc;
 import com.tomkeuper.bedwars.commands.bedwars.MainCommand;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.npc.skin.Skin;
 import net.citizensnpcs.npc.skin.SkinnableEntity;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -110,7 +111,10 @@ public class JoinNPC {
         if (!npc.isSpawned()) {
             npc.spawn(l);
         }
-        if (npc.getEntity() instanceof SkinnableEntity) ((SkinnableEntity) npc.getEntity()).setSkinName(skin);
+        if (npc.getEntity() instanceof SkinnableEntity) {
+            SkinnableEntity skinnableNPC = (SkinnableEntity) npc.getEntity();
+            Skin.get(skin, true).apply(skinnableNPC);
+        }
         npc.setProtected(true);
         npc.setName("");
         String separator = "\\\\n";


### PR DESCRIPTION
Update the API for citizens NPCs
Refactor deprecated API call for skins
Fixes #482 

Tested on Paper 1.21.8 with [Citizens-2.0.40-b3958.jar](https://ci.citizensnpcs.co/job/Citizens2/3958/artifact/dist/target/Citizens-2.0.40-b3958.jar)

<img width="854" height="480" alt="2026-08-01_16 41 20" src="https://github.com/user-attachments/assets/c5542aaf-3d4b-44c1-9949-1cd53ba44996" />
