### PR TITLE
Fix Java 21 target for ASP adapter test classpath

### DIFF
--- a/resetadapter_advancedslimepaper/build.gradle
+++ b/resetadapter_advancedslimepaper/build.gradle
@@ -10,8 +10,10 @@ dependencies {
     compileOnly 'commons-io:commons-io:2.11.0'
 }
 
-// Target Java 21 bytecode for this module
-tasks.named('compileJava', JavaCompile) {
+// Target Java 21 bytecode for this module.
+// Must cover compileTestJava too: ASP 4.0.0 is an `implementation` dependency, so it lands on the
+// test runtime classpath, and its metadata requires org.gradle.jvm.version 21.
+tasks.withType(JavaCompile).configureEach {
     options.release = 21
 }
 


### PR DESCRIPTION
### Identify the Bug

Fixes #491 

<!-- TODO: replace with the issue link before submitting -->

Building the project fails on `:resetadapter_advancedslimepaper:test` with a dependency resolution error:

```
Dependency resolution is looking for a library compatible with JVM runtime version 17,
but 'com.infernalsuite.asp:file-loader:4.0.0' is only compatible with JVM runtime
version 21 or newer.
```

The message is misleading: it is not about the JVM running Gradle (reproduced with Gradle JVM 21). It is the `org.gradle.jvm.version` attribute Gradle derives from `options.release`.

### Description of the Change

`bedwars.base-conventions` applies `options.release = 17` to **every** `JavaCompile` task:

```groovy
tasks.withType(JavaCompile).configureEach {
    options.release = 17
}
```

`resetadapter_advancedslimepaper` then overrides it back up to 21, but only for the `compileJava` task:

```groovy
tasks.named('compileJava', JavaCompile) {
    options.release = 21
}
```

That leaves `compileTestJava` at 17. Gradle uses each source set's compile task target to stamp `org.gradle.jvm.version` onto the matching resolvable configurations, so `testCompileClasspath` and `testRuntimeClasspath` are requesting 17.

`com.infernalsuite.asp:file-loader:4.0.0` is declared as `implementation`, not `compileOnly`, so it is on the test runtime classpath, and its Gradle Module Metadata declares that it requires JVM version 21. Requesting 17 against a variant that only offers 21 is unsatisfiable, so resolution fails before `:test` runs.

The fix widens the module's override from a single task to all `JavaCompile` tasks, so the test classpaths get the same target as the main one:

```groovy
tasks.withType(JavaCompile).configureEach {
    options.release = 21
}
```

The subproject's `configureEach` is registered after the one from the convention plugin (the root `build.gradle` applies conventions during root evaluation, before subproject scripts are evaluated), so 21 correctly wins.

This module is the only one affected today. The other modules that target 21 (`versionsupport_v1_20_*`, `versionsupport_v1_21_*`) keep all their Java-21 artifacts as `compileOnly`, which never propagates to the test classpaths.

### Alternate Designs

* **Raise `options.release` to 21 in `bedwars.base-conventions`.** Rejected: it would silently bump every module, including `versionsupport_1_8_r3` / `versionsupport_1_12_r1` / `bedwars-api`, which deliberately compile to 11 for legacy server support.
* **Move `file-loader` to `compileOnly`.** This would also make the error go away, but the artifact is intentionally on the runtime classpath and shaded into the adapter jar, so this would be a behaviour change, not a build fix.
* **Disable the `test` task for the module.** The project currently has no test sources at all, so this would work, but it hides the misconfiguration instead of fixing it and would break the moment tests are added.
* **Fix the same `tasks.named('compileJava')` pattern across all 21 modules.** Deliberately left out to keep this PR scoped to the actual failure. Happy to extend it if maintainers prefer the sweep in one go.

### Possible Drawbacks

None identified for this module. It already produced Java 21 bytecode for its main source set and its only non-`compileOnly` runtime dependency requires Java 21, so raising the test source set to match cannot lower compatibility of anything shipped.

The change is scoped to one module's build script and touches no plugin code, so runtime behaviour is unchanged.

### Verification Process

Reproduced and verified on Windows 11, Gradle 9.0.0-rc-2 (wrapper), Temurin JDK 21.0.11.

1. Before the change, with `JAVA_HOME` set to JDK 21:

   ```
   ./gradlew :resetadapter_advancedslimepaper:test
   ```

   Failed with the `JVM runtime version 17` resolution error quoted above, confirming the Gradle JVM was not the cause.

2. After the change, the same command succeeds.

3. Ran the module's full build:

   ```
   ./gradlew :resetadapter_advancedslimepaper:build
   ```

   `BUILD SUCCESSFUL`. `compileJava` and `shadowJar` execute as before, and `compileTestJava` / `test` report `NO-SOURCE` — the module has no test sources, so the task was only ever failing while resolving its classpath, never while executing anything.

<!--
TODO before submitting: confirm the full `./gradlew build` also passes on your machine
so you can state that the aggregated shadowJar is unaffected.
-->

### Release Notes

Fixed a build failure in the AdvancedSlimePaper reset adapter module caused by a Java version mismatch on the test classpath.