### PR TITLE
ci: deploy the JavaDoc with easySFTP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,15 +138,17 @@ jobs:
         run: ./gradlew clean publishToMavenLocal --no-daemon --stacktrace
       - name: Build JavaDoc
         run: ./gradlew javadoc --no-daemon --stacktrace
-      - name: Create key for Deploy
-        run: |
-          echo "${{ secrets.JDC_PRIVATE_KEY }}" > ./id_rsa
       - name: Deploy JavaDoc 🚀
-        uses: wangyucode/sftp-upload-action@v2.0.4
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.JDC_IP_ADDRESS }}
           username: ${{ secrets.JDC_USER }}
-          privateKey: './id_rsa'
-          localDir: 'bedwars-api/build/docs/javadoc'
-          remoteDir: '/var/www/tomkeuper.com/javadocs'
-          removeExtraFilesOnServer: true
+          private-key: ${{ secrets.JDC_PRIVATE_KEY }}
+          source: 'bedwars-api/build/docs/javadoc'
+          target: '/var/www/tomkeuper.com/javadocs'
+          # Replaces removeExtraFilesOnServer: uploads changed files and
+          # deletes the ones a previous run put there and that are now gone.
+          mode: sync
+          # Same trust model as before. Once a JDC_KNOWN_HOSTS secret exists,
+          # replace this with: known-hosts: ${{ secrets.JDC_KNOWN_HOSTS }}
+          allow-any-host-key: true

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -102,15 +102,17 @@ jobs:
         run: ./gradlew clean publishToMavenLocal --no-daemon --stacktrace
       - name: Build JavaDoc
         run: ./gradlew javadoc --no-daemon --stacktrace
-      - name: Create key for Deploy
-        run: |
-          echo "${{ secrets.JDC_PRIVATE_KEY }}" > ./id_rsa
       - name: Deploy JavaDoc 🚀
-        uses: wangyucode/sftp-upload-action@v2.0.2
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.JDC_IP_ADDRESS }}
           username: ${{ secrets.JDC_USER }}
-          privateKey: './id_rsa'
-          localDir: 'bedwars-api/build/docs/javadoc'
-          remoteDir: '/var/www/tomkeuper.com/javadocs'
-          removeExtraFilesOnServer: true
+          private-key: ${{ secrets.JDC_PRIVATE_KEY }}
+          source: 'bedwars-api/build/docs/javadoc'
+          target: '/var/www/tomkeuper.com/javadocs'
+          # Replaces removeExtraFilesOnServer: uploads changed files and
+          # deletes the ones a previous run put there and that are now gone.
+          mode: sync
+          # Same trust model as before. Once a JDC_KNOWN_HOSTS secret exists,
+          # replace this with: known-hosts: ${{ secrets.JDC_KNOWN_HOSTS }}
+          allow-any-host-key: true


### PR DESCRIPTION
Disclosure up front: I maintain easySFTP, so this PR proposes my own action. Close it without ceremony if you would rather not switch.

Both JavaDoc deploy steps (`deploy.yml` on `production`, `deploy_snapshot.yml` on `development`) move from `wangyucode/sftp-upload-action` to `eiserv/easySFTP@v3`. Secret names are unchanged (`JDC_IP_ADDRESS`, `JDC_USER`, `JDC_PRIVATE_KEY`), so nothing needs configuring in repo settings first.

## What changes

| before | after | note |
| --- | --- | --- |
| `localDir` | `source` | |
| `remoteDir` | `target` | |
| `privateKey: './id_rsa'` | `private-key: ${{ secrets.JDC_PRIVATE_KEY }}` | the secret goes straight to the action |
| `removeExtraFilesOnServer: true` | `mode: sync` | see below |
| | `allow-any-host-key: true` | see below |

The `Create key for Deploy` step is gone. easySFTP takes the key content as an input, so there is no need to `echo` the private key into `./id_rsa` in the workspace first. That step also had a side effect worth being rid of: the key stayed on disk for the rest of the job, inside the checkout, where any later step could read it.

## About `mode: sync`, and one thing to know before merging

`removeExtraFilesOnServer` in `wangyucode/sftp-upload-action@v2` lists the whole remote tree, compares it against the local tree, and deletes whatever is only on the server.

easySFTP's `sync` gets to the same place differently: it keeps a small `.easysftp-manifest.json` in the target directory recording every file it uploaded and its content hash. On each run it uploads what changed and deletes files that **it** previously uploaded and that no longer exist locally. Files it never uploaded are never touched.

Practical difference on the first run after merging: there is no manifest yet, so that run uploads everything and deletes nothing. If stale pages from removed API classes are currently sitting in `/var/www/tomkeuper.com/javadocs`, they will survive. From the second run on, deletions behave as you expect.

If you want a clean baseline, change `mode: sync` to `mode: clean` for one run, let it go through, then change it back. `clean` wipes the target directory and uploads everything.

Two smaller notes on `sync`:

- It compares SHA-256 content hashes, not size and mtime. A JavaDoc rebuild that regenerates every file with identical content uploads nothing, where the old comparison could be fooled the other way by a same-size change.
- The manifest lives inside the target, so it is reachable at `https://tomkeuper.com/javadocs/.easysftp-manifest.json`. It lists relative paths and hashes. For public JavaDoc that is not a disclosure of anything, but you should know it is there rather than find it later. It can be renamed to something unguessable via a config file if you would rather.

For what it is worth, `wangyucode/sftp-upload-action@v3` has since moved to the same manifest based approach, for the same reason: listing a JavaDoc tree over SFTP costs a round trip per directory, and JavaDoc is mostly directories.

## About `allow-any-host-key: true`

easySFTP refuses to connect unless you either pin the server's host key or state explicitly that you do not want to. `wangyucode/sftp-upload-action` connects through a paramiko `Transport` with no host key policy at all, so `allow-any-host-key: true` is what keeps today's behaviour. Merging this changes your trust model in neither direction.

The upgrade is one line whenever you want it:

```
ssh-keyscan <JDC host>
```

put the output in a `JDC_KNOWN_HOSTS` secret, replace `allow-any-host-key: true` with `known-hosts: ${{ secrets.JDC_KNOWN_HOSTS }}`. Multiple lines are accepted, so paste every key the server offers.

## Why change

**Uploads are atomic per file.** The old action writes straight into the destination path. easySFTP streams each file to a temporary sibling and renames it over the target only after the transfer completed, so an interrupted deploy leaves the previous page live instead of a half written one.

**It retries.** A dropped connection is currently a failed job partway through several thousand small files. easySFTP redials on connection level errors within a run wide retry budget and continues, and a run that fails anyway still records what it managed to change, so the next run resumes rather than starting over.

**It is faster on this shape of payload.** JavaDoc is the worst case for a serial uploader: many small files, each costing its own round trip. `wangyucode/sftp-upload-action@v2` uses `ssh2-sftp-client` and walks the uploads in one loop on one connection. easySFTP transfers files in parallel (4 by default) and keeps multiple write requests in flight inside each file (16 by default), hashes the local tree across a worker pool, and with `sync` skips unchanged files entirely instead of stat'ing them one by one over the wire.

**Fewer moving parts at runtime.** easySFTP is a composite action that downloads one static Go binary and checks it against the release checksums. No `npm`, no `pip install` at job time.

Also available if useful: `dry-run`, `files-uploaded` / `files-deleted` / `bytes-uploaded` / `duration-ms` step outputs, a job summary table, and a `safety.max_deletes` limit that aborts a run that suddenly wants to delete more than expected.

Docs: https://github.com/eiserv/easySFTP

I could not test this against your server. The input mapping above is mechanical and nothing else in either workflow moved. Happy to change the `sync` decision to `clean` if you would rather have exact parity with the old behaviour from the first run.
